### PR TITLE
Add an initial working application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# SBOM Creation for RIOT OS Based Applications
+
+## About
+
+The `sbom_riot` Python package is designed to generate and manage the Software
+Bill of Materials (SBOM) for RIOT OS based software projects.
+
+## Installing
+
+Please build & install using [uv](https://docs.astral.sh/uv/).
+
+## Running
+
+This package is intended to be mainly executed through its command line
+interface. After activating your virtual environment you should have
+the `riot-sbom` script installed there.
+
+Traced builds may take a longer time. The package therefore allows to save
+data in between steps. Running a traced build on an application can be achieved
+with:
+
+```console
+riot-sbom --app-dir <path-to-your-application> --save-app-info <path/to/app_info.pkl>
+```
+
+Saving is in pickle format. It is not intended for storage of data.
+If the save option is provided, updates to the application information
+will be saved or overwritten after the build and after each plugin execution.
+Loading from a file can be combined with saving after executing plugins to
+create intermediates before writing to any output formats:
+
+```console
+riot-sbom --load-app-info <path/to/app_info.pkl> \
+    --save-app-info <path/to/app_info2.pkl>
+    --plugin-pipeline copyrights-scanner authors-scanner spdx-identifiers-scanner \
+                      system-package-provider infer-file-data-from-package
+```
+
+With a valid application information object, one or several output generator
+plugins can also be executed in the pipeline:
+
+```console
+riot-sbom --load-app-info <path/to/app_info.pkl> \
+    --output-file-prefix <path/to/outfilebase> \
+    --plugin-pipeline copyrights-scanner authors-scanner spdx-identifiers-scanner \
+                      system-package-provider infer-file-data-from-package spdx-generator
+```
+
+All tasks can be executed in one go of course, without saving
+intermediate information to the file system:
+
+```console
+riot-sbom --app-dir <path-to-your-application> \
+    --output-file-prefix <path/to/outfilebase> \
+    --plugin-pipeline copyrights-scanner authors-scanner spdx-identifiers-scanner \
+                      system-package-provider infer-file-data-from-package spdx-generator
+```
+
+Available default plugins can be listed via `riot-sbom --list-plugins`.
+
+## Extending
+
+The package supports dynamic loading of plugins.
+If you have plugins implementing `riot_sbom.processing.plugin_type.Plugin`,
+you can provide their directories on the command line for loading.
+
+The following command will load and list all available plugins:
+
+```console
+riot-sbom --external-plugin-dirs <path/to/plugin/dir1> <path/to/plugin/dir2> --list-plugins
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "riot_sbom"
+version = "0.0.1"
+description = "Create an sbom for a RIOT application"
+authors = [{name = "Daniel Lockau", email = "daniel.lockau@ml-pa.com"}]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = "<4.0,>=3.12"
+dependencies = [
+    "spdx-tools<1.0.0,>=0.8.2",
+    "scancode-toolkit<33.0.0,>=32.3.3",
+]
+
+[project.scripts]
+riot-sbom = "riot_sbom.cli:main"
+
+[dependency-groups]
+test = [
+    "jsonschema<5.0.0,>=4.23.0",
+]
+
+[build-system]
+requires = ["uv_build>=0.8.5,<0.9.0"]
+build-backend = "uv_build"
+
+[tool.uv]
+default-groups = []
+package = true

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+
+exec python -m unittest discover -s ${SCRIPT_DIR}/src -p '*.py'

--- a/src/riot_sbom/__init__.py
+++ b/src/riot_sbom/__init__.py
@@ -1,0 +1,10 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from .api import *

--- a/src/riot_sbom/__main__.py
+++ b/src/riot_sbom/__main__.py
@@ -1,0 +1,14 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    from .cli import main
+    main()

--- a/src/riot_sbom/api.py
+++ b/src/riot_sbom/api.py
@@ -1,0 +1,73 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from .data.app_info import AppInfo
+from .processing.build_scanner import BuildScanner
+from .processing import plugin_registry
+import logging
+logger = logging.getLogger(__name__)
+import pathlib
+import pickle
+
+def run_build(app_dir: pathlib.Path) -> AppInfo:
+    """
+    Run the build process for a RIOT application.
+
+    :param app_dir: The directory of the RIOT application.
+    """
+    if not app_dir.is_dir():
+        raise ValueError(f'{app_dir} is not a directory')
+    if not app_dir.joinpath('Makefile').is_file():
+        raise ValueError(f'{app_dir} does not contain a Makefile')
+    scanner = BuildScanner(app_dir)
+    logger.info(f'Running build scanner on {app_dir}')
+    scanner.run()
+    return scanner.get_app_info()
+
+def load_app_info(file: pathlib.Path) -> AppInfo:
+    """
+    Load application information from a file.
+
+    :param file: The file to load the application information from.
+    """
+    if not file.is_file():
+        raise ValueError(f'{file} is not a file')
+    with open(file, 'rb') as f:
+        logger.info(f'Loading application information from {file}')
+        app_info = pickle.load(f)
+        if not isinstance(app_info, AppInfo):
+            raise ValueError(f'{file} does not contain valid application information')
+        return app_info
+
+def save_app_info(app_info: AppInfo, file: pathlib.Path) -> None:
+    """
+    Save application information to a file.
+
+    :param app_info: The application information to save.
+    :param file: The file to save the application information to.
+    """
+    if not file.parent.is_dir():
+        raise ValueError(f'{file.parent} is not a directory. Cannot create output file.')
+    with open(file, 'wb') as f:
+        logger.info(f'Saving application information to {file}')
+        pickle.dump(app_info, f)
+
+def run_plugin(plugin: str, app_info: AppInfo, output_file_prefix: pathlib.Path | None) -> AppInfo:
+    """
+    Run a processing plugin plugin on the application information.
+
+    :param app_info: The application information to process.
+    :param plugin: The name of the plugin to run.
+    :param output_file: The file to write the output to.
+    """
+    plugin_instance = plugin_registry.get_plugin(plugin)
+    if plugin_instance is None:
+        raise ValueError(f'Plugin {plugin} not found')
+    logger.info(f'Running plugin {plugin}')
+    return plugin_instance.run(app_info, output_file_prefix)

--- a/src/riot_sbom/cli.py
+++ b/src/riot_sbom/cli.py
@@ -1,0 +1,110 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from .api import run_build
+from .api import load_app_info
+from .api import save_app_info
+from .api import run_plugin
+
+from pathlib import Path
+import logging
+logger = logging.getLogger(__name__)
+from typing import List
+import sys
+
+def main() -> int:
+    from .processing import plugin_registry
+    import argparse
+    parser = argparse.ArgumentParser(description='RIOT SBOM generator')
+    parser.add_argument('--app-dir', type=Path,
+                        help='Path to the directory of the application for which the SBOM should be built. `make -j` should build the application in that directory. Ignored if loading application information from a file, required otherwise.',
+                        required=False)
+    parser.add_argument('--save-app-info', type=Path,
+                        help='Path to the file where application information is saved in python pickle format. Will be ignored if loading application information from a file. This step will run after the application build and after each successfully executed input plugin.',
+                        required=False)
+    parser.add_argument('--load-app-info', type=Path,
+                        help='Path to the file from which application information is loaded in python pickle format. This will not execute an application build. All selected input plugins will be re-executed.',
+                        required=False)
+    parser.add_argument('--output-file-prefix', type=Path,
+                        help='Prefix of output files, without extension. Required if output plugins are selected.',
+                        required=False)
+    parser.add_argument('--external-plugin-dirs', nargs='+', type=Path,
+                        help='List of directories to search for loadable plugins.',
+                        required=False)
+    parser.add_argument('--list-plugins', action='store_true',
+                        help='List all available plugins and exit.',
+                        required=False)
+    parser.add_argument('--plugin-pipeline', nargs='*', type=str,
+                        help='List of input processing plugins to use for extraction of information or output generation. Plugins are expected to overwrite content created by other plugins, so highest priority should go last for anything altering the application information.',
+                        required=False,
+                        default=[])
+    args = parser.parse_args()
+
+    # Load external plugins
+    for ext_dir in args.external_plugin_dirs or []:
+        if ext_dir.is_dir():
+            plugin_registry.load_plugins_from_directory(ext_dir)
+        else:
+            logger.error(f"Extension directory {ext_dir} does not exist. Aborting.")
+            return 1
+    if args.list_plugins:
+        plugin_registry.print_plugin_list()
+        return 0
+
+    # Verify command line arguments
+    non_existing_plugins = [x for x in args.plugin_pipeline
+                            if x not in plugin_registry.get_plugin_names()]
+    if non_existing_plugins:
+        logger.error(f"The following selected plugins are not available: {non_existing_plugins}. Please run with `--list-plugins` to list available plugins.")
+        return 1
+    if args.load_app_info and args.app_dir:
+        logger.error("Cannot specify both `--load-app-info` and `app-dir`. Please use one of them.")
+        return 1
+    if args.app_dir and not args.app_dir.is_dir():
+        logger.error(f"Application directory {args.app_dir} does not exist. Aborting.")
+        return 1
+    if args.app_dir and not args.app_dir.joinpath('Makefile').is_file():
+        logger.error(f"Application directory {args.app_dir} does not contain a Makefile. Aborting.")
+        return 1
+    if args.save_app_info and not args.save_app_info.parent.is_dir():
+        logger.error(f"Cannot create output file {args.save_app_info}. Parent directory does not exist. Aborting.")
+        return 1
+    if args.load_app_info and not args.load_app_info.is_file():
+        logger.error(f"Cannot load application information from {args.load_app_info}. File does not exist. Aborting.")
+        return 1
+
+    # Get application information
+    if args.load_app_info:
+        app_info = load_app_info(args.load_app_info)
+    elif not args.app_dir:
+        logger.error("No application directory specified and no application information file to load. Please specify either `--app-dir` or `--load-app-info`.")
+        parser.print_help(sys.stderr)
+        return 1
+    else:
+        app_info = run_build(args.app_dir)
+        if args.save_app_info:
+            save_app_info(app_info, args.save_app_info)
+
+    if not app_info:
+        logger.error("No application information available. Aborting.")
+        return 1
+
+    # Run input plugins
+    logger.info(f"Running plugins: {args.plugin_pipeline}")
+    for plugin in args.plugin_pipeline:
+        new_app_info = run_plugin(plugin, app_info, args.output_file_prefix)
+        if not new_app_info:
+            logger.warning(f"Plugin {plugin} does not conform to output spec.")
+        elif args.save_app_info:
+            save_app_info(app_info, args.save_app_info)
+
+    return 0
+
+if __name__ == '__main__':
+    main()

--- a/src/riot_sbom/data/app_info.py
+++ b/src/riot_sbom/data/app_info.py
@@ -1,0 +1,29 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+from typing import Dict
+
+from .file_info import FileInfo
+from .package_info import PackageInfo, PackageReference
+
+
+@dataclass
+class AppInfo:
+    """
+    Application information for a RIOT application.
+    """
+    build_dir: Path
+    app_package_ref: PackageReference
+    riot_package_ref: PackageReference
+    board_package_ref: PackageReference
+    packages: Dict[PackageReference, PackageInfo]
+    files: List[FileInfo]

--- a/src/riot_sbom/data/author_info.py
+++ b/src/riot_sbom/data/author_info.py
@@ -1,0 +1,29 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+__all__ = ["AuthorDeclarationType", "AuthorInfo"]
+
+from dataclasses import dataclass
+from enum import Enum
+
+class AuthorDeclarationType(Enum):
+    """
+    Different types of declarations for an author.
+    A file can contain the author details in its text or they can be derived
+    for from the package details.
+    """
+    TEXT_TAGGED = "text_tagged"
+    TEXT_MATCHED = "text_matched"
+    DERIVED = "derived"
+
+@dataclass
+class AuthorInfo:
+    name: str
+    email: str
+    declaration_type: AuthorDeclarationType

--- a/src/riot_sbom/data/checked_url.py
+++ b/src/riot_sbom/data/checked_url.py
@@ -1,0 +1,81 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import urllib.parse
+import re
+import unittest
+
+__all__ = ["CheckedUrl"]
+
+
+_git_ssh_url_regex = re.compile(
+    r"^(?P<user>[^@]+)@(?P<host>[^:]+):/?(?P<path>.+)$"
+)
+
+class CheckedUrl:
+    """
+    Class to represent a checked URL.
+    This class is used to store the URL and the result of the check.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.__text: str = text
+        self.__valid: bool = False
+        self.__url: str = ""
+        self.__check_url()
+
+    def __check_url(self) -> None:
+        parsed_url = urllib.parse.urlsplit(self.__text)
+        if parsed_url.scheme and parsed_url.netloc:
+            self.__url = urllib.parse.urlunsplit(parsed_url)
+            self.__valid = True
+        else:
+            self.__url = ""
+            self.__valid = False
+        if not self.__valid:
+            # This might be a git ssh URL
+            # e.g. user@host:repo.git
+            # Let's try to parse it and convert it to a valid URL
+            git_url_match = _git_ssh_url_regex.match(self.__text)
+            if git_url_match:
+                user = git_url_match.group("user")
+                host = git_url_match.group("host")
+                path = git_url_match.group("path")
+                self.__url = f"git+ssh://{user}@{host}/{path}"
+                self.__valid = True
+
+    def get(self) -> str:
+        return str(self)
+
+    def __str__(self) -> str:
+        return self.__url
+
+
+class TestCheckedUrl(unittest.TestCase):
+    def test_valid_url(self):
+        url = CheckedUrl("https://example.com")
+        self.assertEqual(str(url), "https://example.com")
+
+    def test_invalid_url(self):
+        url = CheckedUrl("invalid_url")
+        self.assertEqual(str(url), "")
+
+    def test_git_ssh_url(self):
+        url = CheckedUrl("user@host:repo.git")
+        self.assertEqual(str(url), "git+ssh://user@host/repo.git")
+        url = CheckedUrl("user@host:/path/to/repo.git")
+        self.assertEqual(str(url), "git+ssh://user@host/path/to/repo.git")
+        url = CheckedUrl("user@host:path/to/repo.git")
+        self.assertEqual(str(url), "git+ssh://user@host/path/to/repo.git")
+
+
+if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/data/copyright_info.py
+++ b/src/riot_sbom/data/copyright_info.py
@@ -1,0 +1,31 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+__all__ = ["CopyrightDeclarationType", "CopyrightInfo"]
+
+from dataclasses import dataclass
+from enum import Enum
+
+class CopyrightDeclarationType(Enum):
+    """
+    Different types of declarations for a copyright.
+    A file can contain the copyright text or it can be derived for
+    a file from the package copyright.
+    """
+    TEXT_TAGGED = "text_tagged"
+    TEXT_MATCHED = "text_matched"
+    DERIVED = "derived"
+
+@dataclass
+class CopyrightInfo:
+    holder: str
+    years: str
+    declaration_type: CopyrightDeclarationType
+    tag: str | None
+    url: str | None

--- a/src/riot_sbom/data/file_info.py
+++ b/src/riot_sbom/data/file_info.py
@@ -1,0 +1,76 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+from pathlib import Path
+from typing import List
+import unittest
+import weakref
+
+from .package_info import PackageReference
+from .copyright_info import CopyrightInfo
+from .license_info import LicenseInfo
+from .author_info import AuthorInfo
+
+__all__ = ['DigestType', 'FileInfo']
+
+
+class DigestType(Enum):
+    """
+    Different types of digests for a file.
+    """
+    SHA1 = 'sha1'
+    MD5 = 'md5'
+    SHA256 = 'sha256'
+    SHA512 = 'sha512'
+    SHA3_256 = 'sha3_256'
+    SHA3_384 = 'sha3_384'
+    SHA3_512 = 'sha3_512'
+
+
+@dataclass
+class FileInfo:
+    path: Path # path to the file
+    package: PackageReference | None # identifying data which references the package this file belongs to
+    licenses: List[LicenseInfo] | None # none means no license, empty list means unknown
+    copyrights: List[CopyrightInfo] | None # none means no copyright, empty list means unknown
+    authors: List[AuthorInfo] | None # none means no author (e.g. auto-generated), empty list means unknown
+
+    def __post_init__(self):
+        if not self.path.exists():
+            raise FileNotFoundError(f"File {self.path} does not exist.")
+        if not self.path.is_file():
+            raise ValueError(f"Path {self.path} is not a file.")
+        self.digests = {
+            digest_type: FileInfo.get_digest(self.path, digest_type) for digest_type in DigestType
+        }
+
+    @staticmethod
+    def get_digest(path: Path, digest_type: DigestType) -> str:
+        with open(path, 'rb') as f:
+            return hashlib.file_digest(f, digest_type.value).hexdigest()
+
+
+class TestFileInfo(unittest.TestCase):
+    def test_get_digest(self):
+        file = Path(__file__)
+        # Create a FileInfo object
+        file_info = FileInfo(path=file, package=None,
+                             licenses=[], copyrights=None, authors=None)
+        for digest_type in DigestType:
+            expected_digest = hashlib.new(digest_type.value, file.read_bytes()).hexdigest()
+            self.assertEqual(file_info.digests[digest_type], expected_digest, f"Digest mismatch for {digest_type.value}")
+
+
+if __name__ == '__main__':
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/data/license_info.py
+++ b/src/riot_sbom/data/license_info.py
@@ -1,0 +1,35 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+__all__ = ["LicenseDeclarationType", "LicenseInfo"]
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .checked_url import CheckedUrl
+
+class LicenseDeclarationType(Enum):
+    """
+    Different types of declarations for a license.
+    A package or file can contain the license text, reference a license by
+    defined name or have an inexact match to a license. If no match exists,
+    a license can still be derived for a file from the package license or
+    for a package from its contained files.
+    """
+    TEXT_CONTAINED = "text_contained"
+    EXACT_REFERENCE = "exact_reference"
+    INEXACT_MATCH = "inexact_match"
+    DERIVED = "derived"
+
+@dataclass
+class LicenseInfo:
+    declaration_text: str
+    declaration_type: LicenseDeclarationType
+    license_text: str | None
+    url: CheckedUrl | None

--- a/src/riot_sbom/data/package_info.py
+++ b/src/riot_sbom/data/package_info.py
@@ -1,0 +1,62 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+__all__ = ["PackageInfo"]
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from .author_info import AuthorInfo
+from .copyright_info import CopyrightInfo
+from .license_info import LicenseInfo
+from .checked_url import CheckedUrl
+
+
+@dataclass
+class PackageInfo:
+    # @TODO parent package reference?
+    name: str
+    supplier: str | None
+    authors: List[AuthorInfo] | None
+    version: str | None
+    source_dir: Path | None
+    download_url: CheckedUrl | None
+    licenses: List[LicenseInfo] | None
+    copyrights: List[CopyrightInfo] | None
+
+
+class PackageReference:
+    """
+    A reference to a package, uniquely identified by its name and source directory.
+
+    This has been added to avoid multiple references to the same package
+    as well as weak references, as they will not serialize via pickle.
+    """
+    def __init__(self, pkg_name: str, source_dir: Path | None = None):
+        if not pkg_name:
+            raise ValueError("Package name must not be empty.")
+        self.__ref = f"{pkg_name}--{source_dir.absolute().as_posix()
+                                  if source_dir else ''}"
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, PackageReference):
+            return False
+        return self.__ref == value.__ref
+
+    def __hash__(self) -> int:
+        return hash(self.__ref)
+
+
+    @classmethod
+    def from_package_info(cls, pkg: PackageInfo) -> 'PackageReference':
+        """
+        Create a PackageReference from a PackageInfo object.
+        """
+        return cls(pkg.name, pkg.source_dir)

--- a/src/riot_sbom/processing/__init__.py
+++ b/src/riot_sbom/processing/__init__.py
@@ -1,0 +1,31 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from . import plugin_registry
+from . import plugin_type
+from . import input_plugins
+from . import output_plugins
+
+__all__ = [
+    'plugin_registry',
+    'plugin_type',
+    'input_plugins',
+    'output_plugins'
+]
+
+from pathlib import Path
+import logging
+logger = logging.getLogger(__name__)
+
+for pkg in [input_plugins, output_plugins]:
+    if not pkg.__file__:
+        logger.error(f"Cannot load default plugins from {pkg.__name__}: __file__ is None")
+        continue
+    for mod in plugin_registry._load_modules_from_directory(Path(pkg.__file__).parent, False):
+        plugin_registry._load_plugins_from_module(mod)

--- a/src/riot_sbom/processing/_test_plugins/test_plugin_1.py
+++ b/src/riot_sbom/processing/_test_plugins/test_plugin_1.py
@@ -1,0 +1,46 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from riot_sbom.processing.plugin_type import Plugin
+
+class TestPlugin1_1(Plugin):
+    """
+    Plugin subclass for testing purposes.
+    """
+    def __init__(self):
+        super().__init__()
+        self._name = "TestPlugin1_1"
+        self._description = "Test plugin for testing purposes."
+
+    def get_name(self):
+        """
+        Get the name of the plugin.
+        """
+        return self._name
+
+    def get_description(self):
+        """
+        Get the description of the plugin.
+        """
+        return self._description
+
+    def run(self, app_info, output_file_prefix):
+        # This is a dummy implementation for testing purposes.
+        # In a real plugin, this method would process the application information and write the output to a file.
+        print(f"Running {self._name} on {app_info} with output file prefix {output_file_prefix}")
+        return app_info
+
+
+class TestPlugin1_2(TestPlugin1_1):
+    """
+    Plugin subclass for testing purposes.
+    """
+    def __init__(self):
+        self._name = "TestPlugin1_2"
+        self._description = "Test plugin for testing purposes."

--- a/src/riot_sbom/processing/_test_plugins/test_plugin_2.py
+++ b/src/riot_sbom/processing/_test_plugins/test_plugin_2.py
@@ -1,0 +1,18 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import test_plugin_1
+
+class TestPlugin2(test_plugin_1.TestPlugin1_1):
+    """
+    Plugin subclass for testing purposes.
+    """
+    def __init__(self):
+        self._name = "TestPlugin2"
+        self._description = "Test plugin for testing purposes."

--- a/src/riot_sbom/processing/build_scanner.py
+++ b/src/riot_sbom/processing/build_scanner.py
@@ -1,0 +1,448 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import glob
+import logging
+logger = logging.getLogger(__name__)
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import pathlib
+    import sys
+    pkg_path = pathlib.Path(__file__).absolute().parents[2].as_posix()
+    sys.path.insert(0, pkg_path)
+    from riot_sbom.data.app_info import AppInfo
+    from riot_sbom.data.package_info import PackageInfo, PackageReference
+    from riot_sbom.data.file_info import FileInfo
+    from riot_sbom.data.checked_url import CheckedUrl
+    from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+    from riot_sbom.util import text_processing
+    from riot_sbom.util import git_queries
+else:
+    from ..data.app_info import AppInfo
+    from ..data.package_info import PackageInfo, PackageReference
+    from ..data.file_info import FileInfo
+    from ..data.checked_url import CheckedUrl
+    from ..data.license_info import LicenseInfo, LicenseDeclarationType
+    from ..util import text_processing
+    from ..util import git_queries
+
+__all__ = ["BuildScanner"]
+
+class BuildScanner(object):
+    def __init__(self, app_dir: pathlib.Path):
+        """
+        Initialize the build scanner with the given application directory.
+
+        :param app_dir: The path to the application directory.
+        :type app_dir: pathlib.Path
+        """
+        self._app_dir = app_dir
+        self._app_data = {}
+        self._riot_data = {}
+        self._board_data = {}
+        self._external_module_data = []
+        self._package_data = []
+        self._file_data = []
+        self._executed = False
+
+    def run(self):
+        """
+        Executes the build scanning process.
+        This method performs the following steps:
+        1. Extract sbom relevant package data from the Makefile build system.
+        2. Run a traced build process for the application.
+        3. Parse the trace file to gather the paths of the files actually used for the build.
+        4. Build the file data by associating files with packages.
+        """
+        self._gather_build_info_from_make()
+        names = set()
+        names.add(self._app_data['name'])
+        names.add(self._board_data['name'])
+        names.update([mod['name'] for mod in self._external_module_data])
+        if len(names) != len(self._external_module_data) + 2:
+            logger.info('Duplicate names found in set of application, board and external modules. Prepending board name to application name.')
+            self._app_data['name'] = f"APPLICATION_{self._app_data['name']}"
+            self._board_data['name'] = f"BOARD_{self._board_data['name']}"
+        with tempfile.TemporaryDirectory() as tempdir:
+            trace_file = os.path.join(tempdir, 'trace.log')
+            self._run_traced_build(trace_file)
+            file_paths = self._parse_trace_file(trace_file)
+        self._build_file_data(file_paths)
+        self._executed = True
+
+    def get_app_info(self) -> AppInfo:
+        """
+        Build an AppInfo object from the gathered build data for subsequent
+        processing steps.
+
+        :return: An AppInfo representation of the data gathered from build system and traced build.
+        :rtype: AppInfo
+        """
+        if not self._executed:
+            raise RuntimeError("Cannot create app info before running build.")
+        app_package=PackageInfo(
+            name=self._app_data['name'],
+            source_dir=pathlib.Path(self._app_data['source_dir']).absolute(),
+            version=None,
+            licenses=None,
+            download_url=None,
+            copyrights=None,
+            authors=None,
+            supplier=None
+        )
+        riot_package=PackageInfo(
+            name='RIOT OS',
+            source_dir=pathlib.Path(self._riot_data['source_dir']).absolute(),
+            version=self._riot_data['version'],
+            licenses=[LicenseInfo(declaration_text=self._riot_data['license'],
+                declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                license_text=None,
+                url=None)],
+            download_url=CheckedUrl(self._riot_data['url']),
+            copyrights=None,
+            authors=None,
+            supplier=None
+        )
+        board_package=PackageInfo(
+            name=self._board_data['name'],
+            source_dir=pathlib.Path(self._board_data['source_dir']).absolute(),
+            version=None,
+            licenses=None,
+            download_url=None,
+            copyrights=None,
+            authors=None,
+            supplier=None)
+        app_info = AppInfo(self._app_data['build_dir'],
+                           PackageReference.from_package_info(app_package),
+                           PackageReference.from_package_info(riot_package),
+                           PackageReference.from_package_info(board_package),
+                           {}, [])
+        app_info.packages[app_info.app_package_ref] = app_package
+        app_info.packages[app_info.riot_package_ref] = riot_package
+        app_info.packages[app_info.board_package_ref] = board_package
+        # add external modules
+        for ext_mod in self._external_module_data:
+            pkg = PackageInfo(
+                name=ext_mod['name'],
+                source_dir=pathlib.Path(ext_mod['source_dir']).absolute(),
+                version=None,
+                licenses=None,
+                download_url=None,
+                copyrights=None,
+                authors=None,
+                supplier=None
+            )
+            app_info.packages[PackageReference.from_package_info(pkg)] = pkg
+        # add RIOT included packages
+        for pkg in self._package_data:
+            pkg = PackageInfo(
+                name=pkg['name'],
+                source_dir=pathlib.Path(pkg['source_dir']).absolute(),
+                version=pkg['version'],
+                licenses=[LicenseInfo(declaration_text=pkg['license'],
+                                      declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                      license_text=None,
+                                      url=None)],
+                download_url=CheckedUrl(pkg['url']),
+                copyrights=None,
+                authors=None,
+                supplier=("RIOT OS"
+                          if pkg['source_dir'].startswith(self._riot_data['source_dir'])
+                          else None)
+            )
+            app_info.packages[PackageReference.from_package_info(pkg)] = pkg
+        # add all files from build trace
+        for file in self._file_data:
+            app_info.files.append(FileInfo(
+                path=pathlib.Path(file['path']).absolute(),
+                package=PackageReference(file['package'][0],
+                                         pathlib.Path(file['package'][1]).absolute()) if file['package'] else None,
+                licenses=None,
+                copyrights=None,
+                authors=None))
+        return app_info
+
+    def _gather_build_info_from_make(self):
+        """
+        Retrieve package information for build by running 'make info-build-json'
+        in the specified application directory.
+
+        :param str app_dir: The directory where the 'make' command should be executed.
+        :raises RuntimeError: If the 'make' command fails or if the output cannot be parsed.
+        """
+        logger.info('Running make info-build-json to retrieve basic build information')
+        make_run = subprocess.run(['make', 'info-build-json'],
+                                      cwd=self._app_dir.as_posix(),
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE)
+        if make_run.returncode != 0:
+            raise RuntimeError('Failed to run make info-build-json')
+        output = make_run.stdout.decode('utf-8')
+        json_info = text_processing.get_trailing_json_object(output)
+        if not isinstance(json_info, dict):
+            raise RuntimeError('Invalid output from make info-build-json')
+        # check completeness of output
+        required_keys = set(["APPLICATION", "RIOTBASE", "APPDIR",
+                         "BOARD", "RIOTPKG", "BOARDDIR", "EXTERNAL_BOARD_DIRS",
+                         "BINDIR", "EXTERNAL_MODULE_DIRS", "EXTERNAL_MODULE_PATHS",
+                         "EXTERNAL_PKG_DIRS", "DEFAULT_MODULE", "USEMODULE", "RIOTPKG"])
+        if required_keys - set(json_info.keys()):
+            print(json_info.keys())
+            raise RuntimeError(f"Required keys are missing in the \"info-build-json\" output {required_keys - set(json_info.keys())}")
+        self._app_data = {
+            "name": json_info["APPLICATION"],
+            "source_dir": json_info["APPDIR"],
+            "build_dir": json_info["BINDIR"]
+        }
+        riot_remotes = git_queries.get_remotes_for_ref('HEAD', pathlib.Path(json_info['RIOTBASE']))
+        if riot_remotes:
+            if len(riot_remotes) > 1:
+                logger.warning(f"Multiple remotes registered for HEAD of {json_info['RIOTBASE']}. Will pick one.")
+            riot_remote_name = riot_remotes[0]
+            riot_remote_url = git_queries.get_url_for_remote(riot_remote_name, pathlib.Path(json_info['RIOTBASE']))
+        else:
+            riot_remote_url = ""
+        self._riot_data = {
+            "source_dir": json_info["RIOTBASE"],
+            "url": riot_remote_url,
+            "version": git_queries.get_git_commit(pathlib.Path(json_info["RIOTBASE"])),
+            "license": "LGPL-2.1-only"
+        }
+        self._board_data = {
+            "name": json_info["BOARD"],
+            "source_dir": json_info["BOARDDIR"]
+        }
+        self._external_module_data = []
+        module_name_regex = re.compile(r' *MODULE[ \t]*[:\?]?=[ \t]*(?P<name>[A-Za-z0-9_]+)([\t ]*#.*)?')
+        for module_path in json_info["EXTERNAL_MODULE_PATHS"]:
+            module_path = module_path.rstrip('/')
+            pkg_makefile = os.path.join(module_path, 'Makefile')
+            if not os.path.isfile(pkg_makefile):
+                raise RuntimeError(f"Loaded module at \"{module_path}\" does not have a Makefile.")
+            module_name = os.path.basename(module_path)
+            with open(pkg_makefile, 'rt') as makefile:
+                for line in makefile:
+                    m = module_name_regex.match(line)
+                    if m and m.group("name"):
+                        module_name = m.group("name")
+                        break
+            self._external_module_data.append(
+                {
+                    "name": module_name,
+                    "source_dir": module_path
+                }
+            )
+        self._package_data = []
+        riotpkgs = [x for x in glob.glob(os.path.join(json_info["RIOTPKG"], "*"))
+                                if os.path.isdir(x) and os.path.isfile(os.path.join(x, "Makefile"))]
+        external_pkgs = []
+        for pkgdir in json_info["EXTERNAL_PKG_DIRS"]:
+            external_pkgs.extend([x for x in glob.glob(os.path.join(pkgdir, "*"))
+                                if os.path.isdir(x) and os.path.isfile(os.path.join(x, "Makefile"))])
+        available_pkgs = {}
+        for pkg in riotpkgs + external_pkgs:
+            available_pkgs[os.path.basename(pkg)] = pkg
+        pkg_url_regex = re.compile(r'^ *PKG_URL[ \t]*[:\?]?=[ \t]*(?P<data>[^# \t\n\r]+)([\t ]*#.*)?$')
+        pkg_ver_regex = re.compile(r'^ *PKG_VERSION[ \t]*[:\?]?=[ \t]*(?P<data>[^# \t\n\r]+)([\t ]*#.*)?$')
+        pkg_lic_regex = re.compile(r'^ *PKG_LICENSE[ \t]*[:\?]?=[ \t]*(?P<data>[^# \t\n\r]+)([\t ]*#.*)?$')
+        for pkg in json_info["USEPKG"]:
+            if not pkg in available_pkgs:
+                raise RuntimeError(f"Could not locate package \"{pkg}\"")
+            pkg_path = available_pkgs[pkg]
+            pkg_makefile = os.path.join(pkg_path, 'Makefile')
+            if not os.path.isfile(pkg_makefile):
+                raise RuntimeError(f"Loaded package at \"{pkg_path}\" does not have a Makefile.")
+            pkg_url = ""
+            pkg_license = ""
+            pkg_version = ""
+            with open(pkg_makefile, 'rt') as makefile:
+                for line in makefile:
+                    m = pkg_url_regex.match(line)
+                    if m:
+                        pkg_url = m.group('data')
+                        continue
+                    m = pkg_lic_regex.match(line)
+                    if m:
+                        pkg_license = m.group('data')
+                        continue
+                    m = pkg_ver_regex.match(line)
+                    if m:
+                        pkg_version = m.group('data')
+                        continue
+            self._package_data.append(
+                {
+                    "name": pkg,
+                    "definition_dir": available_pkgs[pkg],
+                    "source_dir": os.path.join(json_info["RIOTBASE"], "build", "pkg", pkg),
+                    "url": pkg_url,
+                    "version": pkg_version,
+                    "license": pkg_license
+                }
+            )
+
+    def _run_traced_build(self, trace_file: str):
+        """
+        Run a traced build of the application in the specified directory.
+
+        This function performs a clean build followed by a traced build using `strace`.
+        The traced build logs file access operations to the specified trace file.
+
+        :param app_dir: The directory of the application to build.
+        :type app_dir: str
+        :param trace_file: The file where the trace output will be saved.
+        :type trace_file: str
+        :raises RuntimeError: If the clean or build process fails.
+        """
+        app_dir = self._app_dir.as_posix()
+        logger.info('Retrieving file information for build (this may take a while)')
+        clean_cmd = ["make", "-j", "clean"]
+        clean_run = subprocess.run(clean_cmd,
+                cwd=app_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+        if clean_run.returncode != 0:
+            raise RuntimeError(f'Failed to run make clean (stderr="{clean_run.stderr.decode("utf-8")}")')
+        build_cmd = ["strace", "-f",
+                    "-e", "trace=openat,open",
+                    "-e", "quiet=attach,exit,path-resolution,personality,thread-execve,superseded",
+                    "-o", f"{trace_file}", "make", "-j"]
+        trace_run = subprocess.run(build_cmd,
+                cwd=app_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+        if trace_run.returncode != 0:
+            raise RuntimeError(f'Failed to run make trace-build (stderr="{trace_run.stderr.decode("utf-8")}")')
+
+    def _parse_trace_file(self, trace_file: str):
+        """
+        Parses a trace file to extract and resolve file paths.
+
+        This function reads a trace file line by line, looking for lines that contain
+        file open operations (`openat` or `open`). It extracts the file paths from these
+        lines, resolves them to absolute paths, and filters out temporary files and
+        non-regular files.
+
+        :param trace_file: The path to the trace file to be parsed.
+        :type trace_file: str
+        :return: A sorted list of unique file paths found in the trace file.
+        :rtype: list[str]
+        """
+        logger.info('Parsing trace file')
+        file_paths = set()
+        path_matcher = re.compile(r'[^"]*"(.*)"[^"]*')
+        file_matcher = re.compile(r'.*\.(h|hpp|c|cpp|hxx|cxx|c\+\+|s|asm)$')
+        with open(trace_file, 'r') as f:
+            for line in f:
+                if 'openat(' in line or "open(" in line:
+                    match = path_matcher.match(line)
+                    if match:
+                        path = match.group(1)
+                        if file_matcher.match(path):
+                            path = str(pathlib.Path(path).resolve())
+                            # ignore temporary files and only consider regular files
+                            if (not path.startswith('/tmp/')
+                                and os.path.isfile(path)):
+                                file_paths.add(path)
+        return sorted(file_paths)
+
+    def _build_file_data(self, file_paths: list[str]):
+        """
+        Build file data for the given file paths.
+
+        :param sbom_input: The input data for the SBOM (Software Bill of Materials).
+        :type sbom_input: dict
+        :param file_paths: A list of file paths to process.
+        :type file_paths: list
+        :param package_data: A list of package data.
+        :type package_data: list
+        """
+        logger.info('Building file data')
+        for file_path in file_paths:
+            file_info = self._match_package_for_file(file_path)
+            self._file_data.append(file_info)
+
+    def _match_package_for_file(self, file_path):
+        """
+        Retrieve package name for a file, if possible.
+        This function attempts to match a file path to a known package source directory.
+
+        :param file_path: The path to the file being analyzed.
+        :type file_path: str
+        :return: A dictionary containing the file path and the associated package name.
+        :rtype: dict
+        """
+        file_info = {
+            'path': file_path,
+            'package': None
+        }
+        if file_path.startswith(self._riot_data['source_dir']):
+            file_info['package'] = ("RIOT OS", self._riot_data['source_dir'])
+        # package data overrides RIOT data
+        for package in self._package_data:
+            if file_path.startswith(package['source_dir']):
+                file_info['package'] = (package['name'], package['source_dir'])
+                break
+        for ext_mod in self._external_module_data:
+            if file_path.startswith(ext_mod['source_dir']):
+                file_info['package'] = (ext_mod['name'], ext_mod['source_dir'])
+                break
+        if file_path.startswith(self._app_data['source_dir']):
+            file_info['package'] = (self._app_data['name'], self._app_data['source_dir'])
+        return file_info
+
+
+class BuildScannerTest(unittest.TestCase):
+    def test_all(self):
+        riot_dir = os.getenv('RIOTBASE', None)
+        if riot_dir is None:
+            self.skipTest("Environment variable RIOTBASE is not set.")
+        riot_dir = pathlib.Path(riot_dir).absolute()
+        app_dir = riot_dir.joinpath('tests', 'net', 'nanocoap_cli')
+        if not app_dir.exists() or not app_dir.is_dir():
+            self.skipTest(f"Application directory {app_dir} does not exist or is not a directory.")
+        scanner = BuildScanner(app_dir)
+        old_board = os.environ.get('BOARD')
+        os.environ['BOARD'] = 'native64'
+        scanner.run()
+        if old_board is not None:
+            os.environ['BOARD'] = old_board
+        else:
+            del os.environ['BOARD']
+        self.assertEqual(scanner._app_data['name'], 'tests_nanocoap_cli')
+        self.assertEqual(scanner._board_data['name'], 'native64')
+        self.assertIsInstance(scanner._riot_data, dict)
+        self.assertEqual(len(scanner._external_module_data), 0)
+        self.assertGreater(len(scanner._package_data), 0)
+        self.assertGreater(len(scanner._file_data), 0)
+        app_info = scanner.get_app_info()
+        self.assertIsInstance(app_info, AppInfo)
+        self.assertIsNotNone(app_info.app_package_ref)
+        self.assertIsNotNone(app_info.riot_package_ref)
+        self.assertIsNotNone(app_info.board_package_ref)
+        self.assertIn(app_info.app_package_ref, app_info.packages)
+        self.assertEqual(app_info.packages[app_info.app_package_ref].name, 'tests_nanocoap_cli')
+        self.assertIn(app_info.riot_package_ref, app_info.packages)
+        self.assertEqual(app_info.packages[app_info.riot_package_ref].name, 'RIOT OS')
+        self.assertIn(app_info.board_package_ref, app_info.packages)
+        self.assertEqual(app_info.packages[app_info.board_package_ref].name, 'native64')
+        self.assertEqual(len(app_info.packages), len(scanner._package_data)
+                         + len(scanner._external_module_data) + 3)
+        self.assertEqual(len(app_info.files), len(scanner._file_data))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/__init__.py
+++ b/src/riot_sbom/processing/input_plugins/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""

--- a/src/riot_sbom/processing/input_plugins/authors_scanner.py
+++ b/src/riot_sbom/processing/input_plugins/authors_scanner.py
@@ -1,0 +1,125 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0,pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+import logging
+logger = logging.getLogger(__name__)
+import re
+from typing import List
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+
+
+__all__ = ["AuthorsScanner"]
+
+
+_author_matcher = re.compile(r"(?P<tag>@?[Aa][Uu][Tt][Hh][Oo][Rr]:?[ \t]+)?(?P<name>\"?[^@\"<>]+\"?[ \t]+)?<?(?P<email>[a-zA-Z0-9\._-]+@[a-zA-Z0-9-]+\.[a-zA-Z]+)?>?",
+                             re.UNICODE)
+
+
+def _strip_author_name(name: str) -> str:
+    """
+    Strip the author name of leading and trailing whitespace and quotes, if any.
+    """
+    return name.strip(" \t\"")
+
+
+class AuthorsScanner(Plugin):
+    def get_name(self):
+        return "authors-scanner"
+
+    def get_description(self):
+        return "Scans @author fields from source files."
+
+    def run(self, app_info, _):
+        for file in app_info.files:
+            if file.path.exists():
+                authors: List[AuthorInfo] = []
+                with file.path.open("rt") as f:
+                    for line in f:
+                        m = _author_matcher.search(line)
+                        if m:
+                            author = m.group("name")
+                            if author:
+                                author = _strip_author_name(author)
+                            email = m.group("email")
+                            tag = m.group("tag")
+                            if tag and (author or email):
+                                # we accept any data if preceded by an author tag
+                                author_info = AuthorInfo(
+                                    name=author, email=email,
+                                    declaration_type=AuthorDeclarationType.TEXT_TAGGED)
+                            elif author and email:
+                                # we accept full name and email records only otherwise
+                                author_info = AuthorInfo(
+                                    name=_strip_author_name(author), email=email,
+                                    declaration_type=AuthorDeclarationType.TEXT_MATCHED)
+                            else:
+                                continue
+                            authors.append(author_info)
+                            logger.debug(f"Found author: \"{author}\" <{email}> in file: {file.path}")
+                if authors:
+                    file.authors = authors
+        return app_info
+
+
+class TestAuthorMatcher(unittest.TestCase):
+    def test_author_match_success(self):
+        test_cases_match = {
+            "@author \"John Doe\" <john@doe.com>": ("John Doe", "john@doe.com", True),
+            "@author \"Jane Fonda-Doe\" <j.f@doe.com>": ("Jane Fonda-Doe", "j.f@doe.com", True),
+            "@author \"J. Doe\" <john@doe.com>": ("J. Doe", "john@doe.com", True),
+            "@author \"J. Fonda-Doe\" <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "@author J. Doe <john@doe.com>": ("J. Doe", "john@doe.com", True),
+            "@author J. Fonda-Doe <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "@author J. Doe john@doe.com": ("J. Doe", "john@doe.com", True),
+            "@author J. Fonda-Doe j.f@doe.com": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "Author: \"John Doe\" <john@doe.com>": ("John Doe", "john@doe.com", True),
+            "Author: \"Jane Fonda-Doe\" <j.f@doe.com>": ("Jane Fonda-Doe", "j.f@doe.com", True),
+            "Author: \"J. Doe\" <john@doe.com>": ("J. Doe", "john@doe.com", True),
+            "Author: \"J. Fonda-Doe\" <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "Author: J. Doe <john@doe.com>": ("J. Doe", "john@doe.com", True),
+            "Author: J. Fonda-Doe <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "Author: J. Doe john@doe.com": ("J. Doe", "john@doe.com", True),
+            "Author: J. Fonda-Doe j.f@doe.com": ("J. Fonda-Doe", "j.f@doe.com", True),
+            "\"John Doe\" <john@doe.com>": ("John Doe", "john@doe.com", False),
+            "\"Jane Fonda-Doe\" <j.f@doe.com>": ("Jane Fonda-Doe", "j.f@doe.com", False),
+            "\"J. Doe\" <john@doe.com>": ("J. Doe", "john@doe.com", False),
+            "\"J. Fonda-Doe\" <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", False),
+            "J. Doe <john@doe.com>": ("J. Doe", "john@doe.com", False),
+            "J. Fonda-Doe <j.f@doe.com>": ("J. Fonda-Doe", "j.f@doe.com", False),
+            "J. Doe john@doe.com": ("J. Doe", "john@doe.com", False),
+            "J. Fonda-Doe j.f@doe.com": ("J. Fonda-Doe", "j.f@doe.com", False)
+        }
+        for t, a in test_cases_match.items():
+            m = _author_matcher.search(t)
+            self.assertIsNotNone(m, f"Expected match for line: {t}")
+            if m: # make the linter happy
+                self.assertIsNotNone(m.group("name"),
+                                 f"Expected name for line: {t} (groups: {m.groups()})")
+                self.assertIsNotNone(m.group("email"),
+                                 f"Expected email for line: {t} (groups: {m.groups()})")
+                self.assertEqual(_strip_author_name(m.group("name")), a[0],
+                                 f"Expected name: {a[0]} for line: {t} (groups: {m.groups()})")
+                self.assertEqual(m.group("email"), a[1],
+                                 f"Expected email: {a[1]} for line: {t} (groups: {m.groups()})")
+                self.assertEqual(m.group("tag") is not None, a[2],
+                                 f"Expected tag: {a[2]} for line: {t} (groups: {m.groups()})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/copyrights_scanner.py
+++ b/src/riot_sbom/processing/input_plugins/copyrights_scanner.py
@@ -1,0 +1,107 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0,pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+import logging
+logger = logging.getLogger(__name__)
+import re
+from typing import List
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+
+_copyright_matcher = re.compile(
+    r'(?P<tag>[ \t]*SPDX-FileCopyrightText:?|[ \t]*[Cc]opyright \([cC]\)|[ \t]*[Cc]opyright:?|[ \t]*\([cC]\))+[\t ]+(?P<years>[0-9]{4}[0-9, \t-]*)[ \t]+(?P<holder>.*)(\*/)?',
+    re.UNICODE)
+
+__all__ = ["CopyrightsScanner"]
+
+class CopyrightsScanner(Plugin):
+    def get_name(self):
+        return "copyrights-scanner"
+
+    def get_description(self):
+        return "Scans copyright declarations from source files."
+
+    def run(self, app_info, _):
+        for file in app_info.files:
+            if file.path.exists():
+                copyrights: List[CopyrightInfo] = []
+                with file.path.open("rt") as f:
+                    for line in f:
+                        m = _copyright_matcher.search(line)
+                        if m:
+                            holder = m.group("holder")
+                            if holder:
+                                holder = holder.strip()
+                            years = m.group("years")
+                            if years:
+                                years = years.strip()
+                            tag = m.group("tag")
+                            if tag:
+                                tag = tag.strip()
+                            if holder or years:
+                                # we accept any tagged data, even if incomplete
+                                copyright_info = CopyrightInfo(
+                                    holder=holder, years=years,
+                                    declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                    tag=tag if tag else None,
+                                    url=None)
+                                copyrights.append(copyright_info)
+                            logger.debug(f"Found copyright: {years} {holder} in file: {file.path}")
+                if copyrights:
+                    file.copyrights = copyrights
+        return app_info
+
+
+class TestCopyrightsMatcher(unittest.TestCase):
+    def test_copyrights_match_success(self):
+        test_cases_match = {
+            # string concatenation avoids matching the test case
+            "(C)" + " 1759 John Doe": ("1759", "John Doe"),
+            "(c)" + " 1759 John Doe": ("1759", "John Doe"),
+            "Copyright" + " (C)" + " 1759 John Doe": ("1759", "John Doe"),
+            "Copyright" + " (c)" + " 1759 John Doe": ("1759", "John Doe"),
+            "copyright" + " (c)" + " 1759 John Doe": ("1759", "John Doe"),
+            "copyright" + " (C)" + " 1759 John Doe": ("1759", "John Doe"),
+            "copyright" + " 1759 John Doe": ("1759", "John Doe"),
+            "Copyright" + " 1759 John Doe": ("1759", "John Doe"),
+            "Copyright" + "  1759 John Doe": ("1759", "John Doe"),
+            "Copyright" + "  1759\tJohn Doe": ("1759", "John Doe"),
+            "Copyright" + "  1759  John Doe": ("1759 ", "John Doe"),
+            "SPDX-FileCo" + "pyrightText: 1759 John Doe": ("1759", "John Doe"),
+            "SPDX-FileCo" + "pyrightText:  1759 John Doe": ("1759", "John Doe"),
+            "SPDX-FileCo" + "pyrightText:  1759\tJohn Doe": ("1759", "John Doe"),
+            "SPDX-FileCo" + "pyrightText:  1759  John Doe": ("1759 ", "John Doe"),
+        }
+        for t, a in test_cases_match.items():
+            m = _copyright_matcher.search(t)
+            self.assertIsNotNone(m, f"Expected match for line: {t}")
+            if m: # make the linter happy
+                self.assertIsNotNone(m.group("holder"),
+                                 f"Expected holder for line: {t} (groups: {m.groups()})")
+                self.assertIsNotNone(m.group("years"),
+                                 f"Expected years for line: {t} (groups: {m.groups()})")
+                self.assertIsNotNone(m.group("tag"),
+                                 f"Expected tag for line: {t} (groups: {m.groups()})")
+                self.assertEqual(m.group("years"), a[0],
+                                 f"Expected years: {a[0]} for line: {t} (groups: {m.groups()})")
+                self.assertEqual(m.group("holder"), a[1],
+                                 f"Expected holder: {a[1]} for line: {t} (groups: {m.groups()})")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/infer_file_data_from_package.py
+++ b/src/riot_sbom/processing/input_plugins/infer_file_data_from_package.py
@@ -1,0 +1,169 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0, pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+import logging
+logger = logging.getLogger(__name__)
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.app_info import AppInfo
+from riot_sbom.data.package_info import PackageInfo
+from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+
+
+__all__ = ["InferFileDataFromPackage"]
+
+
+class InferFileDataFromPackage(Plugin):
+    def get_name(self):
+        return "infer-file-data-from-package"
+
+    def get_description(self):
+        return "Tries to complete file data from associated package."
+
+    def run(self, app_info: AppInfo, _) -> AppInfo:
+        for file in app_info.files:
+            if file.package and file.package in app_info.packages:
+                package: PackageInfo = app_info.packages[file.package]
+                if not file.copyrights and package.copyrights:
+                    file.copyrights = [CopyrightInfo(
+                        holder=cr.holder,
+                        years=cr.years,
+                        declaration_type=CopyrightDeclarationType.DERIVED,
+                        tag=None,
+                        url=cr.url
+                    ) for cr in package.copyrights]
+                if not file.licenses and package.licenses:
+                    file.licenses = [LicenseInfo(
+                        declaration_text=lic.declaration_text,
+                        declaration_type=LicenseDeclarationType.DERIVED,
+                        license_text=lic.license_text,
+                        url=lic.url
+                    ) for lic in package.licenses]
+                if not file.authors and package.authors:
+                    file.authors = [AuthorInfo(
+                        name=auth.name,
+                        email=auth.email,
+                        declaration_type=AuthorDeclarationType.DERIVED
+                    ) for auth in package.authors]
+        return app_info
+
+
+class TestInferFileDataFromPackage(unittest.TestCase):
+    def test_infer_file_data_from_package(self):
+        import tempfile
+        import pathlib
+        from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+        from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+        from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+        from riot_sbom.data.checked_url import CheckedUrl
+        from riot_sbom.data.package_info import PackageReference
+        from riot_sbom.data.file_info import FileInfo
+        app_package=PackageInfo(
+            name="example-app",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        riot_package=PackageInfo(
+            name="example-riot",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        board_package=PackageInfo(
+            name="example-board",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier")
+        app_info = AppInfo(
+            build_dir=pathlib.Path("/path/to/build"),
+            app_package_ref=PackageReference.from_package_info(app_package),
+            riot_package_ref=PackageReference.from_package_info(riot_package),
+            board_package_ref=PackageReference.from_package_info(board_package),
+            packages={
+                PackageReference.from_package_info(app_package): app_package,
+                PackageReference.from_package_info(riot_package): riot_package,
+                PackageReference.from_package_info(board_package): board_package
+            },
+            files=[]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = pathlib.Path(temp_dir)
+            for ii, pkg in enumerate(app_info.packages.values()):
+                source_file: pathlib.Path = temp_dir_path / f"source_file_{ii}.c"
+                with open(source_file, 'w') as f:
+                    f.write(f"// Source file {ii}")
+                app_info.files.append(FileInfo(
+                    path=source_file,
+                    package=PackageReference.from_package_info(pkg),
+                    licenses=None,
+                    copyrights=None,
+                    authors=None
+                ))
+            this_plugin = InferFileDataFromPackage()
+            app_info = this_plugin.run(app_info, None)
+            for file in app_info.files:
+                self.assertIsNotNone(file.copyrights, f"Expected copyrights to be inferred for file: {file}")
+                self.assertIsNotNone(file.licenses, f"Expected licenses to be inferred for file: {file}")
+                self.assertIsNotNone(file.authors, f"Expected authors to be inferred for file: {file}")
+                if not file.copyrights or not file.licenses or not file.authors:
+                    continue # make linter happy
+                self.assertEqual(len(file.copyrights), 1, f"Expected exactly one copyright for file: {file}")
+                self.assertEqual(len(file.licenses), 1, f"Expected exactly one license for file: {file}")
+                self.assertEqual(len(file.authors), 1, f"Expected exactly one author for file: {file}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/scancode_helper.py
+++ b/src/riot_sbom/processing/input_plugins/scancode_helper.py
@@ -1,0 +1,34 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from scancode.cli import run_scan as scancode_run_scan
+
+# For use with multiprocessing, this helper function has been created
+# in its own module to avoid pickling issues.
+def scancode_scan_file(pth: str):
+    return pth, scancode_run_scan(
+            pth,
+            strip_root=False,
+            full_root=True,
+            processes=-1,
+            quiet=True,
+            verbose=False,
+            keep_temp_files=False,
+            return_results=True,
+            return_codebase=False,
+            max_depth=1,
+            copyright=True,
+            license=True,
+            email=False,
+            url=False,
+            package=False,
+            system_package=False,
+            generated=True,
+            license_score=90,
+            unknown_licenses=False)

--- a/src/riot_sbom/processing/input_plugins/scancode_scanner.py
+++ b/src/riot_sbom/processing/input_plugins/scancode_scanner.py
@@ -1,0 +1,271 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0, pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+
+import logging
+logger = logging.getLogger(__name__)
+import multiprocessing
+import os
+from pathlib import Path
+import re
+from typing import List, Dict
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.app_info import AppInfo
+from riot_sbom.data.file_info import FileInfo
+from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+from riot_sbom.processing.input_plugins.scancode_helper import scancode_scan_file
+
+
+__all__ = ["ScancodeScanner"]
+
+
+class ScancodeScanner(Plugin):
+    def __init__(self, n_procs: int=os.cpu_count() or 1):
+        self.__n_procs: int = n_procs
+
+    def get_name(self):
+        return "scancode-scanner"
+
+    def get_description(self):
+        return "Will use `scancode` to provide file details for authors, copyrights, licenses from a file's contents."
+
+    def run(self, app_info: AppInfo, _) -> AppInfo:
+        logger.info("Scanning files with scancode")
+        # the way scancode is built, we have to pass the files individually
+        # and not as a list of paths as these will always be reduced to a common
+        # prefix, resulting in many redundant scans
+        with multiprocessing.Pool(self.__n_procs) as pool:
+            from scancode.cli import run_scan as scancode_run_scan
+            file_scan_result = pool.starmap(
+                    scancode_scan_file,
+                    [(str(pth), ) for pth in set(file.path
+                                                 for file in app_info.files
+                                                 if file.path.exists())])
+        author_matcher = re.compile(r'([^<]*)? *(<.*>)?')
+        copyright_matcher = re.compile(
+            r'(?P<tag>[ \t]*SPDX-FileCopyrightText:?|[ \t]*[Cc]opyright|[ \t]*\([cC]\))*[\t ]*(?P<years>[0-9]{4}[0-9, \t-]*)[ \t]+(?P<holder>.*)(\*/)?',
+            re.UNICODE)
+        scancode_output_transformed: Dict[Path, FileInfo] = {}
+        logger.debug(f"Transforming scancode output (number of results: {len(file_scan_result)})",)
+        for ii in range(len(file_scan_result)):
+            pth = file_scan_result[ii][0]
+            if not file_scan_result[ii][1][0]:
+                logger.warning(f"Scancode did not return any results for file: {pth}")
+            else:
+                scan_result = file_scan_result[ii][1][1]
+                logger.debug(f"Processing scan result {ii}: {file_scan_result[ii]}")
+                pth = Path('/' + scan_result['files'][0]['path'])
+                logger.debug(f"Processing file: {pth}")
+                path_scan_result = FileInfo(
+                    path=pth,
+                    package=None,
+                    licenses=None,
+                    authors=None,
+                    copyrights=None,
+                )
+                if (scan_result.get('files') and
+                        scan_result.get('files')[0].get('copyrights')):
+                    path_scan_result.copyrights = []
+                    for c in scan_result['files'][0]['copyrights']:
+                        m = copyright_matcher.match(c['copyright'])
+                        if m:
+                            years = m.group('years')
+                            if years:
+                                years = years.strip()
+                            holder = m.group('holder')
+                            if holder:
+                                holder = holder.strip()
+                            tag = m.group('tag')
+                            if tag:
+                                tag = tag.strip()
+                            path_scan_result.copyrights.append(CopyrightInfo(
+                                holder=holder,
+                                years=years,
+                                declaration_type=CopyrightDeclarationType.TEXT_TAGGED if tag else CopyrightDeclarationType.TEXT_MATCHED,
+                                tag=tag,
+                                url=None))
+                if (scan_result.get('files') and
+                        scan_result.get('files')[0].get('authors')):
+                    authors: List[AuthorInfo] = []
+                    for c in scan_result['files'][0]['authors']:
+                        m = author_matcher.match(c['author'])
+                        if m:
+                            name = m.group(1)
+                            if name:
+                                name = name.strip(" \t\"")
+                            email = m.group(2)
+                            if email:
+                                email = email.strip(' \t<>')
+                            authors.append(AuthorInfo(
+                                name=name,
+                                email=email,
+                                declaration_type=AuthorDeclarationType.TEXT_MATCHED))
+                    path_scan_result.authors = authors
+                if scan_result.get('license_detections'):
+                    path_scan_result.licenses = [
+                            LicenseInfo(
+                                declaration_text=l['license_expression_spdx'],
+                                declaration_type=LicenseDeclarationType.INEXACT_MATCH,
+                                license_text=None, url=None)
+                            for l in scan_result['license_detections']]
+                if not path_scan_result.licenses and (scan_result.get('files') and
+                        scan_result.get('files')[0]
+                        .get('detected_license_expression_spdx')):
+                    path_scan_result.licenses = [
+                            LicenseInfo(
+                                declaration_text=(scan_result
+                                    .get('files')[0]
+                                    .get('detected_license_expression_spdx')
+                                    .replace('\n', '')),
+                                declaration_type=LicenseDeclarationType.INEXACT_MATCH,
+                                license_text=None, url=None)
+                            ]
+                logger.debug(f"Transformed scan result for {pth}: "
+                                f"authors={path_scan_result.authors}, "
+                                f"copyrights={path_scan_result.copyrights}, "
+                                f"licenses={path_scan_result.licenses}")
+                scancode_output_transformed[pth] = path_scan_result
+        for file in app_info.files:
+            if (file.path in scancode_output_transformed
+                    and (scancode_output_transformed[file.path].authors
+                         or scancode_output_transformed[file.path].copyrights
+                         or scancode_output_transformed[file.path].licenses)):
+                scan_result = scancode_output_transformed[file.path]
+                # This overwrites the file's data with the scancode results
+                if scan_result.authors:
+                    file.authors = scan_result.authors
+                if scan_result.copyrights:
+                    file.copyrights = scan_result.copyrights
+                if scan_result.licenses:
+                    file.licenses = scan_result.licenses
+            else:
+                logger.info(f"Scancode did not return any data for file: {file.path}")
+        return app_info
+
+
+class TestScanCodeScanner(unittest.TestCase):
+    def test_infer_file_data_from_package(self):
+        import tempfile
+        import pathlib
+        from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+        from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+        from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+        from riot_sbom.data.checked_url import CheckedUrl
+        from riot_sbom.data.package_info import PackageInfo, PackageReference
+        from riot_sbom.data.file_info import FileInfo
+        app_package=PackageInfo(
+            name="example-app",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        riot_package=PackageInfo(
+            name="example-riot",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        board_package=PackageInfo(
+            name="example-board",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier")
+        app_info = AppInfo(
+            build_dir=pathlib.Path("/path/to/build"),
+            app_package_ref=PackageReference.from_package_info(app_package),
+            riot_package_ref=PackageReference.from_package_info(riot_package),
+            board_package_ref=PackageReference.from_package_info(board_package),
+            packages={
+                PackageReference.from_package_info(app_package): app_package,
+                PackageReference.from_package_info(riot_package): riot_package,
+                PackageReference.from_package_info(board_package): board_package
+            },
+            files=[]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = pathlib.Path(temp_dir)
+            for ii, pkg in enumerate(app_info.packages.values()):
+                source_file: pathlib.Path = temp_dir_path / f"source_file_{ii}.c"
+                with open(source_file, 'wt') as f:
+                    f.write(f"// Source file {ii}\n")
+                    f.write("// SPDX-License-Identifier: MIT\n")
+                    f.write("// Copyright (C) 2025 Example Holder\n")
+                    f.write("// @author John Doe <john@doe.com>\n")
+                app_info.files.append(FileInfo(
+                    path=source_file,
+                    package=PackageReference.from_package_info(pkg),
+                    licenses=None,
+                    copyrights=None,
+                    authors=None
+                ))
+                with source_file.open('rt') as f:
+                    logger.debug(f"Added file {source_file} to app_info.files with content:\n"
+                                f"{f.read()}")
+            this_plugin = ScancodeScanner()
+            app_info = this_plugin.run(app_info, None)
+            for file in app_info.files:
+                self.assertIsNotNone(file.copyrights, f"Expected copyrights to be added for file: {file}")
+                self.assertIsNotNone(file.licenses, f"Expected licenses to be added for file: {file}")
+                self.assertIsNotNone(file.authors, f"Expected authors to be added for file: {file}")
+                if not file.copyrights or not file.licenses or not file.authors:
+                    continue # make linter happy
+                self.assertEqual(len(file.copyrights), 1, f"Expected exactly one copyright for file: {file}")
+                self.assertEqual(len(file.licenses), 1, f"Expected exactly one license for file: {file}")
+                self.assertEqual(len(file.authors), 1, f"Expected exactly one author for file: {file}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/spdx_identifier_scanner.py
+++ b/src/riot_sbom/processing/input_plugins/spdx_identifier_scanner.py
@@ -1,0 +1,96 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0,pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+import logging
+logger = logging.getLogger(__name__)
+import re
+from typing import List
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+
+_spdx_identifier_matcher = re.compile(r'SPDX-License-Identifier:[ \t]*(?P<license>[\w \t\(\)+\.-]{3,}?)[ \t]*(\*/)?$', re.UNICODE)
+
+__all__ = ["SpdxIdsScanner"]
+
+class SpdxIdsScanner(Plugin):
+    def get_name(self):
+        return "spdx-identifiers-scanner"
+
+    def get_description(self):
+        return "Scans SPDX identifier based license declarations from source files."
+
+    def run(self, app_info, _):
+        for file in app_info.files:
+            if file.path.exists():
+                licenses: List[LicenseInfo] = []
+                with file.path.open("rt") as f:
+                    for line in f:
+                        m = _spdx_identifier_matcher.search(line)
+                        if m:
+                            license = m.group("license")
+                            if license:
+                                license = license.strip()
+                                if not license.strip('()-.+'):
+                                    # invalid or empty license statement
+                                    logger.warning(f"Found empty SPDX identifier in line: {line} of file: {file.path}")
+                                    continue
+                                license_info = LicenseInfo(
+                                    declaration_text=license,
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    url=None,
+                                    license_text=None
+                                )
+                                licenses.append(license_info)
+                            logger.debug(f"Found SPDX identifier: {license} in file: {file.path}")
+                if licenses:
+                    file.licenses = licenses
+        return app_info
+
+
+class TestSpdxIdsMatcher(unittest.TestCase):
+    def test_spdx_ids_match_success(self):
+        test_cases_match = {
+            # string concatenation avoids matching the test case
+            "SPDX-License-Identifier" + ": MIT": "MIT",
+            "SPDX-License-Identifier" + ": Apache-2.0": "Apache-2.0",
+            "SPDX-License-Identifier" + ": GPL-3.0-or-later": "GPL-3.0-or-later",
+            "SPDX-License-Identifier" + ": BSD-3-Clause": "BSD-3-Clause",
+            "SPDX-License-Identifier" + ": CC-BY-4.0 OR MIT": "CC-BY-4.0 OR MIT",
+            "SPDX-License-Identifier" + ": CC-BY-4.0 OR MIT  \t": "CC-BY-4.0 OR MIT",
+        }
+        for t, a in test_cases_match.items():
+            m = _spdx_identifier_matcher.search(t)
+            self.assertIsNotNone(m, f"Expected match for line: {t}")
+            if m: # make the linter happy
+                self.assertIsNotNone(m.group("license"),
+                                 f"Expected license for line: {t} (groups: {m.groups()})")
+                self.assertEqual(m.group("license"), a,
+                                 f"Expected license: {a} for line: {t} (groups: {m.groups()})")
+
+    def test_spdx_ids_match_fail(self):
+        test_cases_no_match = [
+            # string concatenation avoids matching the test case
+            "SPDX-License-Identifier" + ":  \t@#$%^&*",
+            "SPDX-License-Identifier" + ":  MIT#",
+        ]
+        for t in test_cases_no_match:
+            m = _spdx_identifier_matcher.search(t)
+            self.assertIsNone(m, f"Expected no match for line: \"{t}\"")
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/input_plugins/system_package_provider.py
+++ b/src/riot_sbom/processing/input_plugins/system_package_provider.py
@@ -1,0 +1,131 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0,pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+import logging
+logger = logging.getLogger(__name__)
+import os
+import pathlib
+import subprocess
+from typing import Dict
+import unittest
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.data.package_info import PackageInfo, PackageReference
+from riot_sbom.data.app_info import AppInfo
+
+def _find_system_package_for_file(file_path: pathlib.Path) -> Dict[str, str] | None:
+    """
+    Finds the system package for a given file path, if any.
+    """
+    if os.name == "nt":
+        raise NotImplementedError("Microsoft Windows is not supported.")
+    elif os.name == "posix":
+        lsb_release_info = subprocess.run(
+            ["lsb_release", "-a"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if lsb_release_info.returncode != 0:
+            raise RuntimeError("lsb_release command failed. This plugin currently only supports Linux with lsb_release available.")
+        # TODO add support for other distributions or package managers
+        lsb_map = {l[0].strip(): l[1].strip() for l in (line.split(":", 1) for line in lsb_release_info.stdout.splitlines()) if len(l) == 2}
+        if 'Distributor ID' not in lsb_map or 'Release' not in lsb_map:
+            raise RuntimeError("lsb_release output does not contain expected fields.")
+        if lsb_map['Distributor ID'] == "Ubuntu":
+            # For Ubuntu, use dpkg to find the package
+            dpkg_query = subprocess.run(
+                ["dpkg", "-S", str(file_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if dpkg_query.returncode == 0:
+                # TODO: add more info from `apt-cache show`
+                return {
+                    'name': dpkg_query.stdout.split(":")[0],
+                    'supplier': lsb_map['Distributor ID'],
+                    'version': lsb_map['Release']
+                }
+        else:
+            raise NotImplementedError(
+                f"System package detection for this OS is not implemented. lsb_release output:\n{lsb_release_info.stdout}")
+
+
+class SystemPackageProvider(Plugin):
+    def get_name(self):
+        return "system-package-provider"
+
+    def get_description(self):
+        return "Will attempt to provide system package references for source files with no package relation."
+
+    def run(self, app_info: AppInfo, _):
+        for file in app_info.files:
+            if not file.package and file.path.exists():
+                system_package = _find_system_package_for_file(file.path)
+                if system_package:
+                    logger.debug(f"Found system package '{system_package}' for file: {file.path}")
+                    package_ref = PackageReference(system_package['name'], pathlib.Path("/"))
+                    if package_ref not in app_info.packages:
+                        app_info.packages[package_ref] = PackageInfo(
+                            name=system_package['name'],
+                            version=system_package.get('version', None),
+                            supplier=system_package.get('supplier', None),
+                            authors=None,
+                            source_dir=pathlib.Path("/"), # for relative file path representation
+                            download_url=None,
+                            licenses=None,
+                            copyrights=None,
+                        )
+                    file.package = package_ref
+                else:
+                    logger.debug(f"No system package found for file: {file.path}")
+        return app_info
+
+
+class TestSystemPackageProvider(unittest.TestCase):
+    def test_find_system_package_for_file(self):
+        # This test assumes that the file exists and is part of a package.
+        # Adjust the file path as necessary for your system.
+        ls_location = subprocess.run(
+            ["which", "ls"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if (ls_location.returncode != 0 or not ls_location.stdout.strip()
+                or not pathlib.Path(ls_location.stdout.strip()).exists()):
+            self.skipTest("The 'ls' command was not found on this system.")
+        test_file = pathlib.Path(ls_location.stdout.strip())
+        package_info = _find_system_package_for_file(test_file)
+        self.assertIsNotNone(package_info)
+        if not package_info:
+            # make linter happy
+            return
+        self.assertIn('name', package_info)
+        self.assertIn('supplier', package_info)
+        self.assertIn('version', package_info)
+
+    def test_no_system_package_found(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile() as temp_file:
+            test_file = pathlib.Path(temp_file.name)
+            package_info = _find_system_package_for_file(test_file)
+            self.assertIsNone(package_info, "Expected no system package to be found for a temporary file.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/output_plugins/__init__.py
+++ b/src/riot_sbom/processing/output_plugins/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""

--- a/src/riot_sbom/processing/output_plugins/spdx_generator.py
+++ b/src/riot_sbom/processing/output_plugins/spdx_generator.py
@@ -1,0 +1,420 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+__all__ = ["SpdxGenerator", "SpdxBuilder"]
+
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import sys
+    import pathlib
+    sys.path.insert(0,pathlib.Path(__file__).absolute().parents[3].as_posix())
+
+
+import logging
+logger = logging.getLogger(__name__)
+import os
+import pathlib
+from datetime import datetime
+from typing import List, Tuple, Any
+import tempfile
+import unittest
+import uuid
+
+from riot_sbom.processing.plugin_type import Plugin
+from riot_sbom.util.file_or_stdout_resource import FileOrStdoutResource
+from riot_sbom.data.app_info import AppInfo
+from riot_sbom.data.package_info import PackageInfo, PackageReference
+from riot_sbom.data.file_info import FileInfo, DigestType
+from riot_sbom.data.license_info import LicenseInfo, LicenseDeclarationType
+from riot_sbom.data.copyright_info import CopyrightInfo, CopyrightDeclarationType
+from riot_sbom.data.author_info import AuthorInfo, AuthorDeclarationType
+from riot_sbom.data.checked_url import CheckedUrl
+
+from spdx_tools.common.spdx_licensing import spdx_licensing
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Checksum,
+    ChecksumAlgorithm,
+    CreationInfo,
+    Document,
+    ExternalPackageRef,
+    ExternalPackageRefCategory,
+    File,
+    FileType,
+    Package,
+    PackagePurpose,
+    PackageVerificationCode,
+    Relationship,
+    RelationshipType,
+)
+from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
+from spdx_tools.spdx.writer.tagvalue.tagvalue_writer import write_document_to_stream
+
+class SpdxBuilder:
+    def __init__(self):
+        """
+        :param document_name: The name of the SPDX document.
+        :param data_license: The SPDX license identifier of the SPDX document.
+        :param document_namespace: The namespace of the SPDX document (URL-formatted).
+        :param creators: A list of tuples containing the name and email of the creators of the SPDX document.
+        """
+        self.__document_ref = "SPDXRef-DOCUMENT"
+        self.__application_ref = "SPDXRef-Application"
+        creation_info = CreationInfo(
+            spdx_version="SPDX-2.3",
+            spdx_id=self.__document_ref,
+            name="Package SBOM for RIOT Application",
+            data_license="CC0-1.0",
+            document_namespace=f'https://spdx.org/spdxdocs/riot-sbom-{uuid.uuid4()}',
+            creators=[Actor(ActorType.TOOL, "riot_sbom", "")],
+            created=datetime.now(),
+        )
+        self.__document = Document(creation_info)
+        self.__package_ref_to_spdx_ref_map = {}
+
+    def set_creation_info(self, document_name: str, data_license: str,
+                          document_namespace: str, creators: List[Tuple[str, str]]):
+        """
+        Set the creation information for the SPDX document.
+        :param document_name: The name of the SPDX document.
+        :param data_license: The SPDX license identifier of the SPDX document.
+        :param document_namespace: The namespace of the SPDX document (URL-formatted).
+        :param creators: A list of tuples containing the name and email of the creators of the SPDX document.
+        """
+        logger.debug("Setting creation information for SPDX document")
+        self.__document.creation_info.name = document_name
+        self.__document.creation_info.data_license = data_license
+        self.__document.creation_info.document_namespace = document_namespace
+        self.__document.creation_info.creators = [
+            Actor(ActorType.PERSON, name, email) for name, email in creators
+        ]
+
+    def add_package(self, package_info: PackageInfo, dependent_package_ref: PackageReference | None=None):
+        """
+        Add a package to the SPDX document.
+        :param package_info: The package information to add.
+        :param dependent_package_ref: The reference of the package that this package depends on, if any.
+
+        :raises ValueError: If the dependent package has not been added yet.
+        :raises ValueError: If the package to add has already been added.
+        """
+        if dependent_package_ref and dependent_package_ref not in self.__package_ref_to_spdx_ref_map:
+            raise ValueError(f"Dependent package {dependent_package_ref} must be added first.")
+        if PackageReference.from_package_info(package_info) in self.__package_ref_to_spdx_ref_map:
+            raise ValueError(f"Package {package_info.name} has already been added to the SPDX document.")
+        dependent_package_ref = (self.__package_ref_to_spdx_ref_map[dependent_package_ref]
+                                if dependent_package_ref else None)
+        logger.debug(f"Adding package {package_info.name} (dependency of {dependent_package_ref})")
+        package_ref = (self.__application_ref
+                       if not dependent_package_ref
+                       else f"SPDXRef-Package-{len(self.__document.packages)}")
+        self.__package_ref_to_spdx_ref_map[PackageReference.from_package_info(package_info)] = package_ref
+        if not package_info.licenses:
+            license_explicit = (SpdxNone()
+                                if package_info.licenses == []
+                                else SpdxNoAssertion())
+            license_concluded = license_explicit
+        else:
+            license_concluded, license_explicit = self._format_licenses(
+                package_info.licenses, package_info.source_dir if package_info.source_dir else None)
+            if len(license_explicit) > 1:
+                logger.warning(f"Package {package_info.name} is associated with more than one explicit license: {package_info.licenses}."
+                                "Picking the first license as explicit license.")
+            license_explicit = license_explicit[0]
+        package = Package(
+            name=package_info.name,
+            spdx_id=package_ref,
+            download_location=package_info.download_url.get() if package_info.download_url else SpdxNoAssertion(),
+            version=package_info.version if package_info.version else None,
+            supplier=Actor(ActorType.ORGANIZATION, package_info.supplier, "") if package_info.supplier is not None else None,
+            files_analyzed=True,
+            license_concluded=license_concluded,
+            #license_info_from_files=[spdx_licensing.parse("GPL-2.0-only"), spdx_licensing.parse("MIT")],
+            license_declared=license_explicit,
+            copyright_text=self._format_copyrights(package_info.copyrights),
+            primary_package_purpose=PackagePurpose.SOURCE if dependent_package_ref else PackagePurpose.APPLICATION,
+        )
+        self.__document.packages.append(package)
+        if self.__application_ref == package_ref:
+            relationship = Relationship(self.__document_ref, RelationshipType.DESCRIBES, package_ref)
+            self.__document.relationships.append(relationship)
+        else:
+            relationship = Relationship(self.__application_ref, RelationshipType.DEPENDS_ON, package_ref)
+            self.__document.relationships.append(relationship)
+
+
+    def add_file(self, file_info: FileInfo, file_package_info: PackageInfo | None=None):
+        logger.debug(f"Adding file {file_info.path} in package {file_package_info}")
+        if file_info.package and not file_package_info:
+            raise ValueError(f"File {file_info.path} belongs to package {file_info.package}, "
+                             f"but no package information was provided.")
+        if file_package_info and not file_info.package:
+            logger.warning(f"File {file_info.path} does not belong to any package, "
+                             f"but package information was provided for {file_package_info.name}. Ignoring package information.")
+            file_package_info = None
+        if file_package_info and PackageReference.from_package_info(file_package_info) not in self.__package_ref_to_spdx_ref_map:
+            raise ValueError(f"Package {file_package_info.name} must be added first.")
+        if file_package_info and PackageReference.from_package_info(file_package_info) != file_info.package:
+            raise ValueError(f"File {file_info.path} does not belong to package {file_package_info.name}.")
+        file_ref = f"SPDXRef-File-{len(self.__document.files) + 1}"
+        if file_info.package is None:
+            file_package_ref = None
+        else:
+            file_package_ref = self.__package_ref_to_spdx_ref_map.get(
+                file_info.package, None)
+        file_name = (file_info.path.name
+                     if not file_package_info
+                     else os.path.relpath(file_info.path, file_package_info.source_dir))
+        if not file_info.licenses:
+            license_explicit = [SpdxNone()
+                                if file_info.licenses == []
+                                else SpdxNoAssertion()]
+            license_concluded = license_explicit[0]
+        else:
+            license_concluded, license_explicit = self._format_licenses(
+                file_info.licenses, file_info.path)
+        file = File(
+            name=file_name,
+            spdx_id=file_ref,
+            file_types=[FileType.SOURCE],
+            checksums=[
+                Checksum(ChecksumAlgorithm.SHA1, file_info.digests[DigestType.SHA1]),
+                Checksum(ChecksumAlgorithm.MD5, file_info.digests[DigestType.MD5]),
+            ],
+            license_concluded=license_concluded,
+            license_info_in_file=license_explicit,
+            copyright_text=self._format_copyrights(file_info.copyrights)
+        )
+        self.__document.files.append(file)
+        if file_package_ref:
+            relationship = Relationship(file_package_ref, RelationshipType.CONTAINS, file_ref)
+            self.__document.relationships.append(relationship)
+        else:
+            relationship = Relationship(self.__application_ref, RelationshipType.DEPENDS_ON, file_ref)
+            self.__document.relationships.append(relationship)
+
+    def write(self, file_path: pathlib.Path | None):
+        logger.info(f"Writing SPDX to {file_path if file_path else 'stdout'}")
+        with FileOrStdoutResource(file_path) as output_stream:
+            write_document_to_stream(self.__document, output_stream, validate=False)
+
+    def validate(self) -> List[ValidationMessage]:
+        return validate_full_spdx_document(self.__document)
+
+    @staticmethod
+    def _format_licenses(licenses: List[LicenseInfo], path: pathlib.Path | None) -> Tuple[Any, List[Any]]:
+        spdx_licenses_concluded = []
+        spdx_licenses_in_file = []
+        for license_info in licenses:
+            try:
+                spdx_license = spdx_licensing.parse(license_info.declaration_text)
+            except:
+                logger.warning(f"License {license_info.declaration_text} in {path} could not be parsed. "
+                                "Skipping.")
+                continue
+            if spdx_license is None:
+                logger.warning(f"License {license_info.declaration_text} in {path} could not be parsed. "
+                                "Using no assertion instead.")
+                spdx_license = SpdxNoAssertion()
+            if license_info.declaration_type == LicenseDeclarationType.DERIVED:
+                if spdx_license not in spdx_licenses_concluded:
+                    spdx_licenses_concluded.append(spdx_license)
+            else:
+                if spdx_license not in spdx_licenses_in_file:
+                    spdx_licenses_in_file.append(spdx_license)
+        spdx_licenses_concluded = [l for l in spdx_licenses_concluded if l != SpdxNoAssertion()]
+        if len(spdx_licenses_concluded) > 1:
+            logger.warning(f"{path} is associated with the following licenses: {licenses}."
+                            "Picking the first license as concluded license.")
+            license_concluded = spdx_licenses_concluded[0]
+        elif len(spdx_licenses_concluded) == 0:
+            license_concluded = SpdxNoAssertion()
+        else:
+            license_concluded = spdx_licenses_concluded[0]
+        license_explicit = [l for l in spdx_licenses_in_file if l != SpdxNoAssertion()]
+        if len(license_explicit) == 0:
+            license_explicit = [SpdxNoAssertion()]
+        return license_concluded, license_explicit
+
+    @staticmethod
+    def _format_copyrights(copyrights: List[CopyrightInfo] | None) -> str | SpdxNoAssertion:
+        return ("".join(f'<text>{(c.tag + " ") if c.tag else ""}{c.years} {c.holder}</text>' for c in copyrights)
+                    if copyrights else SpdxNoAssertion())
+
+
+class SpdxGenerator(Plugin):
+    def get_name(self):
+        return "spdx-generator"
+
+    def get_description(self):
+        return "Writes an spdx file in tag:value format."
+
+    def run(self, app_info: AppInfo, output_file_prefix: pathlib.Path | None) -> AppInfo:
+        logger.info("Generating SPDX document")
+        builder = SpdxBuilder()
+        builder.set_creation_info(
+            document_name=f"SBOM for {app_info.packages[app_info.app_package_ref].name} application",
+            data_license="CC0-1.0",
+            document_namespace=f'https://spdx.org/spdxdocs/riot-sbom-{uuid.uuid4()}',
+            creators=([(author.name, author.email) for author in (app_info.packages[app_info.app_package_ref].authors or [])]
+                      if app_info.packages[app_info.app_package_ref].authors else [])
+        )
+        builder.add_package(app_info.packages[app_info.app_package_ref])
+        for package_ref in app_info.packages:
+            if package_ref == app_info.app_package_ref:
+                continue
+            builder.add_package(
+                app_info.packages[package_ref],
+                app_info.app_package_ref
+            )
+        for file in app_info.files:
+            builder.add_file(file, app_info.packages[file.package] if file.package else None)
+        output_file = output_file_prefix.with_suffix(".sbom.spdx") if output_file_prefix else None
+        logger.debug(f"SPDX document file name: {output_file if output_file else 'stdout'}")
+        builder.write(output_file)
+        validation_messages = builder.validate()
+        if validation_messages:
+            logger.error(f"SPDX document validation failed with {len(validation_messages)} messages.")
+            for message in validation_messages:
+                logger.error(message)
+        else:
+            logger.info("SPDX document validation succeeded.")
+        return app_info
+
+
+class TestSpdxGenerator(unittest.TestCase):
+    def test_spdx_generator(self):
+        app_package=PackageInfo(
+            name="example-app",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        riot_package=PackageInfo(
+            name="example-riot",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier"
+        )
+        board_package=PackageInfo(
+            name="example-board",
+            version="1.0.0",
+            licenses=[LicenseInfo(declaration_text="MIT",
+                                    declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                    license_text=None, url=None)],
+            copyrights=[CopyrightInfo(holder="Example Holder",
+                                        years="2025",
+                                        declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                        tag="SPDX-FileCopyrightText:",
+                                        url=None)],
+            download_url=CheckedUrl("https://example.com/package.tar.gz"),
+            authors=[AuthorInfo(name="John Doe",
+                                email="john@doe.com",
+                                declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+            source_dir=pathlib.Path("/path/to/source"),
+            supplier="Example Supplier")
+        app_info = AppInfo(
+            build_dir=pathlib.Path("/path/to/build"),
+            app_package_ref=PackageReference.from_package_info(app_package),
+            riot_package_ref=PackageReference.from_package_info(riot_package),
+            board_package_ref=PackageReference.from_package_info(board_package),
+            packages={
+                PackageReference.from_package_info(app_package): app_package,
+                PackageReference.from_package_info(riot_package): riot_package,
+                PackageReference.from_package_info(board_package): board_package,
+                PackageReference("example-pkg1", pathlib.Path("/path/to/source")): PackageInfo(
+                    name="example-pkg1",
+                    version="1.0.0",
+                    licenses=[LicenseInfo(declaration_text="MIT",
+                                        declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                        license_text=None, url=None)],
+                    copyrights=[CopyrightInfo(holder="Example Holder",
+                                            years="2025",
+                                            declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                            tag="SPDX-FileCopyrightText:",
+                                            url=None)],
+                    download_url=CheckedUrl("https://example.com/package.tar.gz"),
+                    authors=[AuthorInfo(name="John Doe",
+                                        email="john@doe.com",
+                                        declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+                    source_dir=pathlib.Path("/path/to/source"),
+                    supplier="Example Supplier"
+                ),
+                PackageReference("example-pkg2", pathlib.Path("/path/to/source")): PackageInfo(
+                    name="example-pkg2",
+                    version="1.0.0",
+                    licenses=[LicenseInfo(declaration_text="MIT",
+                                        declaration_type=LicenseDeclarationType.EXACT_REFERENCE,
+                                        license_text=None, url=None)],
+                    copyrights=[CopyrightInfo(holder="Example Holder",
+                                            years="2025",
+                                            declaration_type=CopyrightDeclarationType.TEXT_TAGGED,
+                                            tag="SPDX-FileCopyrightText:",
+                                            url=None)],
+                    download_url=CheckedUrl("https://example.com/package.tar.gz"),
+                    authors=[AuthorInfo(name="John Doe",
+                                        email="john@doe.com",
+                                        declaration_type=AuthorDeclarationType.TEXT_TAGGED)],
+                    source_dir=pathlib.Path("/path/to/source"),
+                    supplier="Example Supplier")
+            },
+            files=[]
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = pathlib.Path(temp_dir)
+            for ii, pkg in enumerate(app_info.packages.values()):
+                source_file = temp_dir_path / f"source_file_{ii}.c"
+                with open(source_file, 'w') as f:
+                    f.write(f"// Source file {ii}")
+                app_info.files.append(FileInfo(
+                    path=source_file,
+                    package=PackageReference.from_package_info(pkg),
+                    licenses=pkg.licenses,
+                    copyrights=pkg.copyrights,
+                    authors=pkg.authors
+                ))
+            plugin = SpdxGenerator()
+            output_file_prefix = temp_dir_path / "test_output"
+            new_app_info = plugin.run(app_info, output_file_prefix)
+            self.assertIsInstance(new_app_info, AppInfo)
+            self.assertEqual(new_app_info, app_info)
+            self.assertTrue(output_file_prefix.with_suffix(".sbom.spdx").exists())
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/plugin_registry.py
+++ b/src/riot_sbom/processing/plugin_registry.py
@@ -1,0 +1,198 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import importlib.util
+import io
+import logging
+logger = logging.getLogger(__name__)
+import os
+from pathlib import Path
+import sys
+from typing import Dict, List, TextIO
+from types import ModuleType
+import unittest
+
+if __name__ == "__main__":
+    # update search path for local testing
+    import pathlib
+    import os
+    import sys
+    pkg_path = pathlib.Path(__file__).absolute().parents[2].as_posix()
+    os.environ["PYTHONPATH"] = ":".join(
+        [pkg_path, os.environ.get("PYTHONPATH", "")]).strip(":")
+    sys.path.insert(0, pkg_path)
+    from riot_sbom.processing.plugin_type import Plugin
+else:
+    from .plugin_type import Plugin
+
+__all__ = ["load_plugins_from_directory", "print_plugin_list",
+              "get_plugin_names", "get_plugin", "register_plugin"]
+
+
+_plugin_registry: Dict[str, Plugin] = {}
+
+
+def _load_modules_from_directory(directory: Path, add_to_search_path=True) -> List[ModuleType]:
+    """
+    Load all modules from the specified directory.
+
+    :param directory: The directory to load modules from.
+    :type directory: str
+    :return: A list of loaded modules.
+    """
+    modules = []
+    for filename in os.listdir(directory):
+        if filename.endswith('.py') and filename != '__init__.py':
+            if add_to_search_path and directory.absolute().as_posix() not in sys.path:
+                # allow loading of local libraries in plugin directory
+                logger.debug(f"Adding {directory.absolute().as_posix()} to sys.path")
+                sys.path.append(directory.absolute().as_posix())
+            module_name = filename[:-3]
+            module_path = os.path.join(directory, filename)
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, module_path)
+                if spec is None or spec.loader is None:
+                    logger.warning(f"Could not load module {module_name} from {module_path}")
+                    continue
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                modules.append(module)
+            except Exception as e:
+                logger.warning(f"Failed to load module {module_name} from {module_path}: {e}")
+                continue
+            logger.debug(f"Loaded module: {module_name} from {module_path}")
+    return modules
+
+
+def register_plugin(name: str, plugin: Plugin) -> None:
+    """
+    Register a plugin with the given name.
+
+    :param name: The name of the plugin.
+    :type name: str
+    :param plugin: The plugin instance.
+    :type plugin: Plugin
+    """
+    logger.debug(f"Registering plugin: {name} to registry: {_plugin_registry}")
+    if not name:
+        raise ValueError("Plugin name cannot be empty.")
+    if name in _plugin_registry:
+        logger.debug(f"Plugin {name} is already registered. Skipping.")
+    if not isinstance(plugin, Plugin):
+        raise TypeError(f"Plugin {name} is not an instance of Plugin.")
+    _plugin_registry[name] = plugin
+    logger.info(f"Registered plugin: {name} - {plugin.get_description()}")
+
+
+def _load_plugins_from_module(module: ModuleType) -> None:
+    logger.debug(f"Loading plugins from module: {module.__name__}")
+    for name, obj in vars(module).items():
+        logger.debug(f"Checking {name} in module {module.__name__}")
+        logger.debug(f"Object type: {type(obj)}")
+        if isinstance(obj, type):
+            logger.debug(f"Object {name} is a class")
+            logger.debug(f"Class {name} is a subclass of Plugin: {issubclass(obj, Plugin)}")
+            logger.debug(f"Class {name} is not Plugin: {obj is not Plugin}")
+        if isinstance(obj, type) and issubclass(obj, Plugin) and obj is not Plugin:
+            try:
+                plugin_instance = obj()
+            except Exception as e:
+                import traceback
+                logger.warning(f"Failed to instantiate plugin {name}: {traceback.format_exc()}")
+                continue
+            register_plugin(plugin_instance.get_name(), plugin_instance)
+
+
+def load_plugins_from_directory(directory: Path) -> None:
+    """
+    Load all plugins from the specified directory.
+
+    :param directory: The directory to load plugins from.
+    :type directory: str
+    :return: A list of loaded plugins.
+    """
+    modules = _load_modules_from_directory(directory)
+    for module in modules:
+        _load_plugins_from_module(module)
+
+
+def print_plugin_list(target: TextIO = sys.stdout) -> None:
+    """
+    Print the list of available plugins.
+    """
+    print("Available plugins:", file=target)
+    for name, plugin in _plugin_registry.items():
+        print(f"---\nPLUGIN: {name}", file=target)
+        print(f"DESCRIPTION: {plugin.get_description()}", file=target)
+
+
+def get_plugin_names() -> List[str]:
+    """
+    Get the names of all available plugins.
+
+    :return: A list of plugin names.
+    """
+    return list(_plugin_registry.keys())
+
+
+def get_plugin(name: str) -> Plugin:
+    """
+    Get a plugin by its name.
+
+    :param name: The name of the plugin.
+    :type name: str
+    :return: The plugin instance.
+    """
+    if name not in _plugin_registry:
+        raise KeyError(f"Plugin {name} not found.")
+    return _plugin_registry[name]
+
+
+class TestPluginRegistry(unittest.TestCase):
+    test_directory = Path(__file__).parent / "_test_plugins"
+
+    def setUp(self):
+        load_plugins_from_directory(TestPluginRegistry.test_directory)
+
+    def tearDown(self):
+        _plugin_registry.clear()
+
+    def test_load_plugins_from_directory(self):
+        _plugin_registry.clear()
+        load_plugins_from_directory(TestPluginRegistry.test_directory)
+        self.assertGreater(len(_plugin_registry), 0, "No plugins loaded from directory")
+
+    def test_get_plugin_names(self):
+        names = get_plugin_names()
+        self.assertIsInstance(names, list, "Plugin names should be a list")
+        self.assertGreater(len(names), 0, "No plugin names found")
+
+    def test_get_plugin(self):
+        names = get_plugin_names()
+        if names:
+            plugin = get_plugin(names[0])
+            self.assertIsInstance(plugin, Plugin, "Retrieved object is not a Plugin instance")
+        else:
+            self.fail("No plugin names found to test get_plugin()")
+
+    def test_print_plugin_list(self):
+        text = io.StringIO()
+        print_plugin_list(text)
+        output = text.getvalue()
+        self.assertIn("Available plugins:", output, "Plugin list should contain 'Available plugins:'")
+        self.assertIn("PLUGIN:", output, "Plugin list should contain 'PLUGIN:'")
+        self.assertIn("DESCRIPTION:", output, "Plugin list should contain 'DESCRIPTION:'")
+
+    def test_plugin_registry(self):
+        # Check if the plugin registry is not empty after loading
+        self.assertEqual(len(_plugin_registry), 3, "Plugin registry should contain 3 plugins")
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/src/riot_sbom/processing/plugin_type.py
+++ b/src/riot_sbom/processing/plugin_type.py
@@ -1,0 +1,57 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from pathlib import Path
+
+from ..data.app_info import AppInfo
+
+
+__all__ = ["Plugin"]
+
+
+class Plugin:
+    """
+    A base class for plugins.
+    This class must be inherited by all plugins.
+    """
+
+    def get_name(self):
+        """
+        Returns the name of the plugin.
+        This method should be overridden by subclasses to provide the
+        plugin's name.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def get_description(self):
+        """
+        Returns a description of the plugin.
+        This method should be overridden by subclasses to provide the
+        plugin's description.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def run(self, app_info: AppInfo, output_file_prefix: Path | None) -> AppInfo:
+        """
+        Runs the plugin on the given app_info and output_file_prefix.
+        This method should be overridden by subclasses to implement the
+        plugin's functionality.
+
+        Implementations may choose to operate on a deep copy of the provided
+        AppInfo object. Normally, the modified original app_info should be
+        returned. Subsequent plugins should always receive the returned
+        AppInfo object.
+
+        :param app_info: The application information to process.
+        :type app_info: AppInfo
+        :param output_file_prefix: The prefix for the output files.
+        :type output_file_prefix: Path | None
+        :return: The processed application information.
+        """
+        raise NotImplementedError("Subclasses must implement this method")

--- a/src/riot_sbom/util/__init__.py
+++ b/src/riot_sbom/util/__init__.py
@@ -1,0 +1,10 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+from .file_or_stdout_resource import FileOrStdoutResource

--- a/src/riot_sbom/util/file_or_stdout_resource.py
+++ b/src/riot_sbom/util/file_or_stdout_resource.py
@@ -1,0 +1,44 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import contextlib
+import sys
+from pathlib import Path
+
+__all__ = ["FileOrStdoutResource"]
+
+class FileOrStdoutResource(contextlib.AbstractContextManager):
+    """
+    A context manager that provides a file or stdout resource.
+    If the output_file_prefix is None, it uses stdout.
+    Otherwise, it creates a file with the given prefix.
+    This may be used for plugins that need to write output to a file
+    or to stdout, depending on the configuration.
+    """
+
+    def __init__(self, output_file_path: Path | None):
+        """
+        Initializes the FileOrStdoutResource.
+
+        :param output_file_path: The prefix for the output file. If None, stdout is used.
+        """
+        self.output_file_path = output_file_path
+        self.output_file = None
+
+    def __enter__(self):
+        if self.output_file is not None:
+            raise RuntimeError("Output file already opened")
+        if self.output_file_path is None:
+            return sys.stdout
+        self.output_file = self.output_file_path.open('wt')
+        return self.output_file
+
+    def __exit__(self, *_):
+        if self.output_file is not None:
+            self.output_file.close()

--- a/src/riot_sbom/util/git_queries.py
+++ b/src/riot_sbom/util/git_queries.py
@@ -1,0 +1,102 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import logging
+logger = logging.getLogger(__name__)
+import pathlib
+import subprocess
+from typing import List
+
+def _get_command_output(cmd: List[str], cwd: pathlib.Path) -> str:
+    """
+    Raising wrapper to subprocess.run, capturing output.
+
+    :param cmd: Command with arguments in subprocess.run list form.
+    :type cmd: list[str]
+    :param cwd: Working directory to execute the command in.
+    :type cwd: pathlib.Path
+    :return: Stdout buffer of the completed process as utf-8 string.
+    :rtype: str
+    :raises ValueError: If cwd parameter is not a directory.
+    :raises RuntimeError: If command fails.
+    """
+    if not pathlib.Path.is_dir(cwd):
+        raise ValueError(f"Parameter \"cwd\" is not a directory: {cwd}")
+    subproc = subprocess.run(cmd,
+                                    cwd=cwd,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+    if subproc.returncode != 0:
+        raise RuntimeError(f"Failed to run command {cmd} (stderr: \"{subproc.stderr.decode('utf-8')}\")")
+    return subproc.stdout.decode('utf-8')
+
+def get_git_commit(cwd: pathlib.Path) -> str:
+    """
+    Return the git commit SHA for the HEAD of the repository pointed to by
+    the given path.
+
+    :param cwd: Directory in which to execute the query.
+    :type cwd: pathlib.Path
+    :return: SHA as string.
+    :rtype: str
+    :raises ValueError: If cwd parameter is not a directory.
+    :raises RuntimeError: If command fails.
+    """
+    return _get_command_output(['git', 'rev-parse', '--verify', 'HEAD'], cwd)
+
+def get_repository_root(cwd: pathlib.Path) -> pathlib.Path:
+    """
+    Return the repository root for the repository pointed to by the given path.
+
+    :param cwd: Directory in which to execute the query.
+    :type cwd: pathlib.Path
+    :return: Root directory of the repository which includes the given path.
+    :rtype: pathlib.Path
+    :raises ValueError: If cwd parameter is not a directory.
+    :raises RuntimeError: If command fails.
+    """
+    return pathlib.PosixPath(_get_command_output(['git', 'rev-parse', '--show-toplevel'], cwd).strip())
+
+def get_remotes_for_ref(ref: str, cwd: pathlib.Path):
+    """
+    Return the names of all remotes which hold a given reference.
+
+    :param ref: Git reference.
+    :type ref: str
+    :param cwd: Directory in which to execute the query.
+    :type cwd: pathlib.Path
+    :return: List of names of the remotes which hold this reference. None if no remote was found (local ref).
+    :rtype: list[str] | None
+    :raises ValueError: If cwd parameter is not a directory.
+    :raises RuntimeError: If command fails.
+    """
+    git_ref = _get_command_output(['git', 'rev-parse', '--verify', ref], cwd).strip()
+    remote_names = set([x.strip().split('/')[0] for x in
+        _get_command_output(['git', 'branch', '-r', '--color=never',
+            '--no-column', '--no-format', '--contains', git_ref], cwd).strip().split('\n')
+            if x.strip()])
+    if not remote_names:
+        logger.warning(f"No remote found for HEAD in repository at {get_repository_root(cwd)}.")
+        return None
+    return list(remote_names)
+
+def get_url_for_remote(remote_name: str, cwd: pathlib.Path):
+    """
+    Return the URL for a given remote.
+
+    :param remote_name: Name of the remote.
+    :type remote_name: str
+    :param cwd: Directory in which to execute the query.
+    :type cwd: pathlib.Path
+    :return: URL of the remote.
+    :rtype: str
+    :raises ValueError: If cwd parameter is not a directory.
+    :raises RuntimeError: If command fails.
+    """
+    return _get_command_output(['git', 'remote', 'get-url', remote_name], cwd).strip()

--- a/src/riot_sbom/util/text_processing.py
+++ b/src/riot_sbom/util/text_processing.py
@@ -1,0 +1,55 @@
+"""
+Copyright (C) 2025 ML!PA Consulting GmbH
+
+SPDX-License-Identifier: MIT
+
+Authors:
+    Daniel Lockau <daniel.lockau@ml-pa.com>
+"""
+
+import json
+
+def get_trailing_json_object(text: str) -> dict:
+    """
+    Extract the last JSON object from the given output string.
+
+    This function searches for the last occurrence of a JSON object
+    in the output string by locating the last closing brace `}` and
+    searching backwards until it finds the corresponding opening brace `{`.
+    It will not match braces in strings so it should work on any JSON
+    object.
+
+    :param text: The string containing at least one JSON object.
+    :type text: str
+    :return: The last JSON object found in the output.
+    :rtype: dict
+    :raises RuntimeError: If no valid JSON object is found.
+    """
+    end = text.rfind('}')
+    if end == -1:
+        raise RuntimeError('No JSON object found in output')
+    start = end
+    brace_count = 0
+    in_string = False
+    for pos in range(end, -1, -1):
+        char = text[pos]
+        if in_string:
+            if pos == 0:
+                raise RuntimeError('Unmatched quote in JSON object')
+            if char == r'"' and text[pos - 1] != r"\\":
+                in_string = False
+        elif char == '"':
+            in_string = True
+        if in_string:
+            continue
+        # not in string
+        if char == '}':
+            brace_count += 1
+        elif char == '{':
+            brace_count -= 1
+            if brace_count == 0:
+                start = pos
+                break
+    if brace_count != 0:
+        raise RuntimeError(f'Unmatched braces in JSON object. ')
+    return json.loads(text[start:end + 1])

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1209 @@
+version = 1
+revision = 3
+requires-python = ">=3.12, <4.0"
+
+[[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "banal"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a7/3301a69b4a31f7324b99332d758ae8da691f7f865ccd1b2adcd973c45344/banal-1.0.6.tar.gz", hash = "sha256:2fe02c9305f53168441948f4a03dfbfa2eacc73db30db4a93309083cb0e250a5", size = 4827, upload-time = "2021-02-24T13:10:21.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/c4/7f6e6a539cc6b2da4da3b6a58d5e6f9342c870522ee46d41f8cbd2156953/banal-1.0.6-py2.py3-none-any.whl", hash = "sha256:877aacb16b17f8fa4fd29a7c44515c5a23dc1a7b26078bc41dd34829117d85e1", size = 6069, upload-time = "2021-02-24T13:10:20.29Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/f9/21e5a9c731e14f08addd53c71fea2e70794e009de5b98e6a2c3d2f3015d6/beartype-0.21.0.tar.gz", hash = "sha256:f9a5078f5ce87261c2d22851d19b050b64f6a805439e8793aecf01ce660d3244", size = 1437066, upload-time = "2025-05-22T05:09:27.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/31/87045d1c66ee10a52486c9d2047bc69f00f2689f69401bb1e998afb4b205/beartype-0.21.0-py3-none-any.whl", hash = "sha256:b6a1bd56c72f31b0a496a36cc55df6e2f475db166ad07fa4acc7e74f4c7f34c0", size = 1191340, upload-time = "2025-05-22T05:09:24.606Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[package.optional-dependencies]
+chardet = [
+    { name = "chardet" },
+]
+
+[[package]]
+name = "binaryornot"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061", size = 371054, upload-time = "2017-08-03T15:55:25.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/7e/f7b6f453e6481d1e233540262ccbfcf89adcd43606f44a028d7f5fae5eb2/binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4", size = 9006, upload-time = "2017-08-03T15:55:31.23Z" },
+]
+
+[[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936, upload-time = "2025-05-02T08:32:33.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790, upload-time = "2025-05-02T08:32:35.768Z" },
+    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924, upload-time = "2025-05-02T08:32:37.284Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626, upload-time = "2025-05-02T08:32:38.803Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567, upload-time = "2025-05-02T08:32:40.251Z" },
+    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957, upload-time = "2025-05-02T08:32:41.705Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408, upload-time = "2025-05-02T08:32:43.709Z" },
+    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399, upload-time = "2025-05-02T08:32:46.197Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815, upload-time = "2025-05-02T08:32:48.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537, upload-time = "2025-05-02T08:32:49.719Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565, upload-time = "2025-05-02T08:32:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357, upload-time = "2025-05-02T08:32:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776, upload-time = "2025-05-02T08:32:54.573Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload-time = "2025-05-02T08:32:56.363Z" },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload-time = "2025-05-02T08:32:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload-time = "2025-05-02T08:33:00.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload-time = "2025-05-02T08:33:02.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload-time = "2025-05-02T08:33:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload-time = "2025-05-02T08:33:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload-time = "2025-05-02T08:33:08.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload-time = "2025-05-02T08:33:09.986Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload-time = "2025-05-02T08:33:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload-time = "2025-05-02T08:33:13.707Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload-time = "2025-05-02T08:33:15.458Z" },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload-time = "2025-05-02T08:33:17.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload-time = "2025-05-02T08:33:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "commoncode"
+version = "32.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "beautifulsoup4", extra = ["chardet"] },
+    { name = "click" },
+    { name = "requests", extra = ["use-chardet-on-py3"] },
+    { name = "saneyaml" },
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/d1/bd6129070f5caae620635d1cf3e28e5ae4f6389c22fa04fcf075c60e9df2/commoncode-32.3.0.tar.gz", hash = "sha256:19b8b696b78774b8c6505a85d40c2a521f0e18ef0b9442561988562785d741b2", size = 1742714, upload-time = "2025-06-11T15:17:06.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/ea/7536234f6ff4b0cf89aa3a3e4c9868ab589e8d1a4ee86fe0a05245c060f7/commoncode-32.3.0-py3-none-any.whl", hash = "sha256:992e502e6b68016247c16b7cbe3b6d741e5a75c075194763bff443b8a5fc75b7", size = 94040, upload-time = "2025-06-11T15:17:04.989Z" },
+]
+
+[[package]]
+name = "container-inspector"
+version = "33.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "commoncode" },
+    { name = "dockerfile-parse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/fe/50dd7a684f740bd66ab2969888723fe6c16acff41629fb731e7e131d78bf/container_inspector-33.0.0.tar.gz", hash = "sha256:09260edb14549648da61260c1559b507e9dcb8296a6324368ba3803ca2011f7c", size = 212468, upload-time = "2024-05-17T17:50:42.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/aa/966e81912c7771269e6608478521a40a16460868a02fa34059b1f8be0737/container_inspector-33.0.0-py3-none-any.whl", hash = "sha256:6284ac158c7115672ab70d1b97a22b6d257b59ee12bebc76c6048585943e919f", size = 40235, upload-time = "2024-05-17T17:50:40.722Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "45.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz", hash = "sha256:5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719", size = 744949, upload-time = "2025-08-05T23:59:27.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/29/2793d178d0eda1ca4a09a7c4e09a5185e75738cc6d526433e8663b460ea6/cryptography-45.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:048e7ad9e08cf4c0ab07ff7f36cc3115924e22e2266e034450a890d9e312dd74", size = 7042702, upload-time = "2025-08-05T23:58:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/b6/cabd07410f222f32c8d55486c464f432808abaa1f12af9afcbe8f2f19030/cryptography-45.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44647c5d796f5fc042bbc6d61307d04bf29bccb74d188f18051b635f20a9c75f", size = 4206483, upload-time = "2025-08-05T23:58:27.132Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/f9c7d36a38b1cfeb1cc74849aabe9bf817990f7603ff6eb485e0d70e0b27/cryptography-45.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e40b80ecf35ec265c452eea0ba94c9587ca763e739b8e559c128d23bff7ebbbf", size = 4429679, upload-time = "2025-08-05T23:58:29.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2a/4434c17eb32ef30b254b9e8b9830cee4e516f08b47fdd291c5b1255b8101/cryptography-45.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:00e8724bdad672d75e6f069b27970883179bd472cd24a63f6e620ca7e41cc0c5", size = 4210553, upload-time = "2025-08-05T23:58:30.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1d/09a5df8e0c4b7970f5d1f3aff1b640df6d4be28a64cae970d56c6cf1c772/cryptography-45.0.6-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7a3085d1b319d35296176af31c90338eeb2ddac8104661df79f80e1d9787b8b2", size = 3894499, upload-time = "2025-08-05T23:58:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/120842ab20d9150a9d3a6bdc07fe2870384e82f5266d41c53b08a3a96b34/cryptography-45.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b7fa6a1c1188c7ee32e47590d16a5a0646270921f8020efc9a511648e1b2e08", size = 4458484, upload-time = "2025-08-05T23:58:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/1bc3634d45ddfed0871bfba52cf8f1ad724761662a0c792b97a951fb1b30/cryptography-45.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:275ba5cc0d9e320cd70f8e7b96d9e59903c815ca579ab96c1e37278d231fc402", size = 4210281, upload-time = "2025-08-05T23:58:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/ffb12c2d83d0ee625f124880a1f023b5878f79da92e64c37962bbbe35f3f/cryptography-45.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f4028f29a9f38a2025abedb2e409973709c660d44319c61762202206ed577c42", size = 4456890, upload-time = "2025-08-05T23:58:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8e/b3f3fe0dc82c77a0deb5f493b23311e09193f2268b77196ec0f7a36e3f3e/cryptography-45.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ee411a1b977f40bd075392c80c10b58025ee5c6b47a822a33c1198598a7a5f05", size = 4333247, upload-time = "2025-08-05T23:58:38.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a6/c3ef2ab9e334da27a1d7b56af4a2417d77e7806b2e0f90d6267ce120d2e4/cryptography-45.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2a21a8eda2d86bb604934b6b37691585bd095c1f788530c1fcefc53a82b3453", size = 4565045, upload-time = "2025-08-05T23:58:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c3/77722446b13fa71dddd820a5faab4ce6db49e7e0bf8312ef4192a3f78e2f/cryptography-45.0.6-cp311-abi3-win32.whl", hash = "sha256:d063341378d7ee9c91f9d23b431a3502fc8bfacd54ef0a27baa72a0843b29159", size = 2928923, upload-time = "2025-08-05T23:58:41.919Z" },
+    { url = "https://files.pythonhosted.org/packages/38/63/a025c3225188a811b82932a4dcc8457a26c3729d81578ccecbcce2cb784e/cryptography-45.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:833dc32dfc1e39b7376a87b9a6a4288a10aae234631268486558920029b086ec", size = 3403805, upload-time = "2025-08-05T23:58:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/af/bcfbea93a30809f126d51c074ee0fac5bd9d57d068edf56c2a73abedbea4/cryptography-45.0.6-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:3436128a60a5e5490603ab2adbabc8763613f638513ffa7d311c900a8349a2a0", size = 7020111, upload-time = "2025-08-05T23:58:45.316Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/ea5173689e014f1a8470899cd5beeb358e22bb3cf5a876060f9d1ca78af4/cryptography-45.0.6-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d9ef57b6768d9fa58e92f4947cea96ade1233c0e236db22ba44748ffedca394", size = 4198169, upload-time = "2025-08-05T23:58:47.121Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/73/b12995edc0c7e2311ffb57ebd3b351f6b268fed37d93bfc6f9856e01c473/cryptography-45.0.6-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea3c42f2016a5bbf71825537c2ad753f2870191134933196bee408aac397b3d9", size = 4421273, upload-time = "2025-08-05T23:58:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6e/286894f6f71926bc0da67408c853dd9ba953f662dcb70993a59fd499f111/cryptography-45.0.6-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:20ae4906a13716139d6d762ceb3e0e7e110f7955f3bc3876e3a07f5daadec5f3", size = 4199211, upload-time = "2025-08-05T23:58:50.139Z" },
+    { url = "https://files.pythonhosted.org/packages/de/34/a7f55e39b9623c5cb571d77a6a90387fe557908ffc44f6872f26ca8ae270/cryptography-45.0.6-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dac5ec199038b8e131365e2324c03d20e97fe214af051d20c49db129844e8b3", size = 3883732, upload-time = "2025-08-05T23:58:52.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b9/c6d32edbcba0cd9f5df90f29ed46a65c4631c4fbe11187feb9169c6ff506/cryptography-45.0.6-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:18f878a34b90d688982e43f4b700408b478102dd58b3e39de21b5ebf6509c301", size = 4450655, upload-time = "2025-08-05T23:58:53.848Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5", size = 4198956, upload-time = "2025-08-05T23:58:55.209Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/061ec6689207d54effdff535bbdf85cc380d32dd5377173085812565cf38/cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016", size = 4449859, upload-time = "2025-08-05T23:58:56.639Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ff/e7d5a2ad2d035e5a2af116e1a3adb4d8fcd0be92a18032917a089c6e5028/cryptography-45.0.6-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:550ae02148206beb722cfe4ef0933f9352bab26b087af00e48fdfb9ade35c5b3", size = 4320254, upload-time = "2025-08-05T23:58:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/aa2f4940262d588a8fdf4edabe4cda45854d00ebc6eaac12568b3a491a16/cryptography-45.0.6-cp37-abi3-win32.whl", hash = "sha256:780c40fb751c7d2b0c6786ceee6b6f871e86e8718a8ff4bc35073ac353c7cd02", size = 2912147, upload-time = "2025-08-05T23:59:01.716Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bc/16e0276078c2de3ceef6b5a34b965f4436215efac45313df90d55f0ba2d2/cryptography-45.0.6-cp37-abi3-win_amd64.whl", hash = "sha256:20d15aed3ee522faac1a39fbfdfee25d17b1284bafd808e1640a74846d7c4d1b", size = 3390459, upload-time = "2025-08-05T23:59:03.358Z" },
+]
+
+[[package]]
+name = "debian-inspector"
+version = "31.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/7a/6f9d38aabf50c1e0449e22e42485047f9d22792664e1006b14aba8d2f604/debian_inspector-31.1.0.tar.gz", hash = "sha256:ebcfbc17064f10bd3b6d2122cdbc97b71a494af0ebbafaf9a8ceadfe8b164f99", size = 191155, upload-time = "2024-02-19T10:29:34.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/61/709907d112553b39c8c907f0f90618de58ec87ca4565959d2ad350c84b9f/debian_inspector-31.1.0-py3-none-any.whl", hash = "sha256:77dfeb34492dd49d8593d4f7146ffa3f71fca703737824e09d7472e0eafca567", size = 45615, upload-time = "2024-02-19T10:29:32.837Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "dparse2"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packvers" },
+    { name = "pyyaml" },
+    { name = "toml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/d2/59a42c7b40c1075d49aa6b5ea32a5baa87f8022d252ccb4762ca9d5a30f5/dparse2-0.7.0.tar.gz", hash = "sha256:6bf6872aeaffedcac67ad0abb516630bad045dbdb58505b58d8f796ee91f0a73", size = 9916, upload-time = "2022-12-23T17:41:53.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/e9/a370e566f84807cff908e71a4824ae00ea8196319f4e2956e82509a5f1c6/dparse2-0.7.0-py3-none-any.whl", hash = "sha256:2b935161700cdad4f27fa7ada85900756739be65ba3ef614ac4436e7ba929102", size = 10887, upload-time = "2022-12-23T17:41:51.247Z" },
+]
+
+[[package]]
+name = "extractcode"
+version = "31.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "commoncode" },
+    { name = "plugincode" },
+    { name = "six" },
+    { name = "typecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/24/40848587ae0f03ec6da2ae8a28b7ace7219fcbad0bc74e84c582324208ed/extractcode-31.0.0.tar.gz", hash = "sha256:80819392e9bcf8129f74d8904fe8a98c0dfed2782356842737282c0283113d88", size = 11305241, upload-time = "2022-05-09T17:38:24.648Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/7e/0a60071cc9fdd2ec364d6fe7d6bc77632a36c44e9d467b4921ba84f9c921/extractcode-31.0.0-py3-none-any.whl", hash = "sha256:9838465035a0e12a744026ef7300c8559fdcce2790cc72faaf2513d1e57a5d94", size = 56676, upload-time = "2022-05-09T17:38:21.969Z" },
+]
+
+[package.optional-dependencies]
+full = [
+    { name = "extractcode-7z" },
+    { name = "extractcode-libarchive" },
+    { name = "typecode", extra = ["full"] },
+]
+
+[[package]]
+name = "extractcode-7z"
+version = "16.5.210531"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/cc/eafd6c23a477af98ec4d2639bb0942563223162a615308de657c2ebeabc9/extractcode_7z-16.5.210531-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:2edab8e1626e6b57593ce20be2ef520ece86616f2b0d7f311a171cddbf21891b", size = 1026867, upload-time = "2021-05-31T11:15:50.483Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9e/c27db5aaeb9edaf50727f9b498d57e1c3adaea79ea16b20391a3dceca928/extractcode_7z-16.5.210531-py3-none-manylinux1_x86_64.whl", hash = "sha256:d92e9063f38add282306ba067b08a808b50ffccca7c3d4b6d23b1a4f1e010a90", size = 1255989, upload-time = "2021-05-31T11:15:53.043Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d5/e9016667b806ec39c776ad3fb2042357bc374fdbe5341e26569cdf120696/extractcode_7z-16.5.210531-py3-none-win_amd64.whl", hash = "sha256:027ffc8721fcd9a31dc3422535ca75d79e2416b0597f53fb54c15d6b9a61042c", size = 933507, upload-time = "2021-05-31T11:15:55.918Z" },
+]
+
+[[package]]
+name = "extractcode-libarchive"
+version = "3.5.1.210531"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/99/8f490830656025c05ba83cf38d93dac5962c189b1d9350a65f62a6e680af/extractcode_libarchive-3.5.1.210531-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:135c1d9b0bcb2e15feaec892e7786e3ed3bf96d604ab44051cb21114313215ed", size = 932657, upload-time = "2021-05-31T11:15:59.241Z" },
+    { url = "https://files.pythonhosted.org/packages/56/6e/8695d5773679fd05bd1c4e56a7b9ab3d5dc3c89aadfa9c1981a00fc66935/extractcode_libarchive-3.5.1.210531-py3-none-manylinux1_x86_64.whl", hash = "sha256:61b97b797c69a6675f38c79f0b456cd38618293d1fbf66f3588f0ba4fa6a1dbe", size = 1226222, upload-time = "2021-05-31T11:16:01.968Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/24/6108ff836b177c5c5edd0c7ca5f04fa95cc49edfcb43c2bf4da577cf38fa/extractcode_libarchive-3.5.1.210531-py3-none-win_amd64.whl", hash = "sha256:164d3f6b1127154dacc7f15f05b37fbc775438a6c62a815376eab7095e4a6159", size = 6962608, upload-time = "2021-05-31T11:16:09.086Z" },
+]
+
+[[package]]
+name = "fasteners"
+version = "0.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d4/e834d929be54bfadb1f3e3b931c38e956aaa3b235a46a3c764c26c774902/fasteners-0.19.tar.gz", hash = "sha256:b4f37c3ac52d8a445af3a66bce57b33b5e90b97c696b7b984f530cf8f0ded09c", size = 24832, upload-time = "2023-09-19T17:11:20.228Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl", hash = "sha256:758819cb5d94cdedf4e836988b74de396ceacb8e2794d21f82d131fd9ee77237", size = 18679, upload-time = "2023-09-19T17:11:18.725Z" },
+]
+
+[[package]]
+name = "fingerprints"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "normality" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/29/8998d631aae6b9940af9248fbb9d269491785055d6f1763f224af0e6cc02/fingerprints-1.3.1-py3-none-any.whl", hash = "sha256:eb246a3e2730689a494f1239a8418e8df98419bb4c2bfed25925f2c624b523c0", size = 25082, upload-time = "2025-08-01T12:32:07.084Z" },
+]
+
+[[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
+name = "gemfileparser2"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/bd/a64f1e4320b125a2685fec90c760339ba2da09d8a49d763a2e61ff4a592e/gemfileparser2-0.9.4.tar.gz", hash = "sha256:7b37e2a01c2564c19bd5c133cf06b569f5d4ad39f1b20a735f408d393c95ce06", size = 83607, upload-time = "2024-08-21T04:58:12.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/69/ee5b89373713a7a34222a8c71d5be1643935cdf06017f65aed2fb2f604f9/gemfileparser2-0.9.4-py3-none-any.whl", hash = "sha256:372e9dff807854a37cdc58c692e150a6bea31031e7d5ce8a2762dd63437b22c0", size = 19504, upload-time = "2024-08-21T04:58:10.741Z" },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "intbitset"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/28/1461048d37d258c820ed7db3cbb847f5cf39830a1ef671e6ac33b62f3607/intbitset-4.0.0.tar.gz", hash = "sha256:c141edaa1c17b91c2987537e269d955ab6bdc3966af3deb6e1e0d20edbd09dd2", size = 192986, upload-time = "2024-10-23T23:13:52.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/56/c08b0a8c74fa352223e196e48f079870574458e30321b6d43b78cd77e030/intbitset-4.0.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:981d7662f717c87241bd7a7ec46b15255cb3f31b4bbd00e6a289f71e52a37488", size = 169180, upload-time = "2024-10-23T23:13:36.522Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/16035b3539585b3ab18c2d5f1515b0f3f6326ce77b88f58eef07043c5c96/intbitset-4.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee02a57a012e27c14f6368a59055eec799a892059594f313747b10138709a595", size = 486432, upload-time = "2024-10-23T23:13:38.638Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4f/73eb717c4de20f457127e89804e526b3715682ff5859e1e3d89b9a7bf031/intbitset-4.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2740fa12d45b0632adef9b466aa923fbfaa7883a0879902c1d6f3e3db85fa506", size = 484561, upload-time = "2024-10-23T23:13:40.777Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/85/eadf49b4e7c9b9095540f56ca785d34fb16bebc8d34c0b63ae0dc721cb66/intbitset-4.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:9436ce5ae5cec6308ece0b717e2861b9fcbc88b58b39d012c00d88246a391022", size = 80812, upload-time = "2024-10-23T23:13:43.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9c/10cb23829db5c1fcb2855fc9ffda89e4a4996352a93cf3f95ff4fb3dfae5/intbitset-4.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c0bfe1d4ff53cb4b157059a49edf06ffa486d1ca08b73f1473273d4c57652850", size = 166742, upload-time = "2024-10-24T02:01:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d2/d616114d3a3006b239292d86963ecbc4836699e2b70596941b873b60d333/intbitset-4.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cc4831d34bc50b159bdb158453e4730b9dba7ea605b47f92421d30ca54fcc0a", size = 479938, upload-time = "2024-10-24T02:01:32.512Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d7/f97dd910c861a997bdb7c635c62f092b1d11bab5d2895db738297db77e61/intbitset-4.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:673ed77360c5b1131f8e7968a54b5f06dc41335357f0fca7f5568a54c5bdb1db", size = 479518, upload-time = "2024-10-24T02:01:35.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0a/71d2854265f61730a00e916e6238f0d223323613999f06b3607718327f7c/intbitset-4.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e740c9abd06de912e06f3d941afc2640b51a9b9bdf3213b7b6f68b371ca4bf96", size = 80449, upload-time = "2024-10-24T02:01:36.723Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1c/831faaaa0f090b711c355c6d8b2abf277c72133aab472b6932b03322294c/jaraco_functools-4.2.1.tar.gz", hash = "sha256:be634abfccabce56fa3053f8c7ebe37b682683a4ee7793670ced17bab0087353", size = 19661, upload-time = "2025-06-21T19:22:03.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/fd/179a20f832824514df39a90bb0e5372b314fea99f217f5ab942b10a8a4e8/jaraco_functools-4.2.1-py3-none-any.whl", hash = "sha256:590486285803805f4b1f99c60ca9e94ed348d4added84b74c7a12885561e524e", size = 10349, upload-time = "2025-06-21T19:22:02.039Z" },
+]
+
+[[package]]
+name = "javaproperties"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/b6/366850e576cc9052b0f5ace2b554d061be9370d95c08b69d0de7212591b2/javaproperties-0.8.2.tar.gz", hash = "sha256:f780d17ca12d57da58519dcf9d821cbcdb6f98a8b5af661013e31a5050c59a0f", size = 40602, upload-time = "2024-12-01T12:48:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/be/cf9d60226f19072d6033dd2696782446272c147f4527c1906ae99b784dcc/javaproperties-0.8.2-py3-none-any.whl", hash = "sha256:30141f83c45b574e204ee8170071535815994f468726813ec90f2d7f9fa6e7c1", size = 23734, upload-time = "2024-12-01T12:48:16.949Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f", size = 356830, upload-time = "2025-07-18T15:39:45.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716", size = 89184, upload-time = "2025-07-18T15:39:42.956Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
+name = "jsonstreams"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/8c/01333839805428590015bb4cbc3b730876609e536954eb1140d24b410bd0/jsonstreams-0.6.0.tar.gz", hash = "sha256:721cda7391e9415b7b15cebd6cf92fc7f8788ca211eda7d64162a066ee45a72e", size = 33544, upload-time = "2021-03-16T17:47:27.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/be/233b55906cc033b890c2e4593077bc10c7e09257c46f5253dd9b2850f3f4/jsonstreams-0.6.0-py2.py3-none-any.whl", hash = "sha256:b2e609c2bc17eec77fe26dae4d32556ba59dafbbff30c9a4909f2e19fa5bb000", size = 10617, upload-time = "2021-03-16T17:47:25.7Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ed/60eb6fa2923602fba988d9ca7c5cdbd7cf25faa795162ed538b527a35411/lxml-6.0.0.tar.gz", hash = "sha256:032e65120339d44cdc3efc326c9f660f5f7205f3a535c1fdbf898b29ea01fb72", size = 4096938, upload-time = "2025-06-26T16:28:19.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/c3/d01d735c298d7e0ddcedf6f028bf556577e5ab4f4da45175ecd909c79378/lxml-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78718d8454a6e928470d511bf8ac93f469283a45c354995f7d19e77292f26108", size = 8429515, upload-time = "2025-06-26T16:26:06.776Z" },
+    { url = "https://files.pythonhosted.org/packages/06/37/0e3eae3043d366b73da55a86274a590bae76dc45aa004b7042e6f97803b1/lxml-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:84ef591495ffd3f9dcabffd6391db7bb70d7230b5c35ef5148354a134f56f2be", size = 4601387, upload-time = "2025-06-26T16:26:09.511Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/28/e1a9a881e6d6e29dda13d633885d13acb0058f65e95da67841c8dd02b4a8/lxml-6.0.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:2930aa001a3776c3e2601cb8e0a15d21b8270528d89cc308be4843ade546b9ab", size = 5228928, upload-time = "2025-06-26T16:26:12.337Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/55/2cb24ea48aa30c99f805921c1c7860c1f45c0e811e44ee4e6a155668de06/lxml-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:219e0431ea8006e15005767f0351e3f7f9143e793e58519dc97fe9e07fae5563", size = 4952289, upload-time = "2025-06-28T18:47:25.602Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c0/b25d9528df296b9a3306ba21ff982fc5b698c45ab78b94d18c2d6ae71fd9/lxml-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bd5913b4972681ffc9718bc2d4c53cde39ef81415e1671ff93e9aa30b46595e7", size = 5111310, upload-time = "2025-06-28T18:47:28.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/af/681a8b3e4f668bea6e6514cbcb297beb6de2b641e70f09d3d78655f4f44c/lxml-6.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:390240baeb9f415a82eefc2e13285016f9c8b5ad71ec80574ae8fa9605093cd7", size = 5025457, upload-time = "2025-06-26T16:26:15.068Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b6/3a7971aa05b7be7dfebc7ab57262ec527775c2c3c5b2f43675cac0458cad/lxml-6.0.0-cp312-cp312-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d6e200909a119626744dd81bae409fc44134389e03fbf1d68ed2a55a2fb10991", size = 5657016, upload-time = "2025-07-03T19:19:06.008Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f8/693b1a10a891197143c0673fcce5b75fc69132afa81a36e4568c12c8faba/lxml-6.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca50bd612438258a91b5b3788c6621c1f05c8c478e7951899f492be42defc0da", size = 5257565, upload-time = "2025-06-26T16:26:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/96/e08ff98f2c6426c98c8964513c5dab8d6eb81dadcd0af6f0c538ada78d33/lxml-6.0.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:c24b8efd9c0f62bad0439283c2c795ef916c5a6b75f03c17799775c7ae3c0c9e", size = 4713390, upload-time = "2025-06-26T16:26:20.292Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/83/6184aba6cc94d7413959f6f8f54807dc318fdcd4985c347fe3ea6937f772/lxml-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:afd27d8629ae94c5d863e32ab0e1d5590371d296b87dae0a751fb22bf3685741", size = 5066103, upload-time = "2025-06-26T16:26:22.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/01/8bf1f4035852d0ff2e36a4d9aacdbcc57e93a6cd35a54e05fa984cdf73ab/lxml-6.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:54c4855eabd9fc29707d30141be99e5cd1102e7d2258d2892314cf4c110726c3", size = 4791428, upload-time = "2025-06-26T16:26:26.461Z" },
+    { url = "https://files.pythonhosted.org/packages/29/31/c0267d03b16954a85ed6b065116b621d37f559553d9339c7dcc4943a76f1/lxml-6.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c907516d49f77f6cd8ead1322198bdfd902003c3c330c77a1c5f3cc32a0e4d16", size = 5678523, upload-time = "2025-07-03T19:19:09.837Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f7/5495829a864bc5f8b0798d2b52a807c89966523140f3d6fa3a58ab6720ea/lxml-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36531f81c8214e293097cd2b7873f178997dae33d3667caaae8bdfb9666b76c0", size = 5281290, upload-time = "2025-06-26T16:26:29.406Z" },
+    { url = "https://files.pythonhosted.org/packages/79/56/6b8edb79d9ed294ccc4e881f4db1023af56ba451909b9ce79f2a2cd7c532/lxml-6.0.0-cp312-cp312-win32.whl", hash = "sha256:690b20e3388a7ec98e899fd54c924e50ba6693874aa65ef9cb53de7f7de9d64a", size = 3613495, upload-time = "2025-06-26T16:26:31.588Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1e/cc32034b40ad6af80b6fd9b66301fc0f180f300002e5c3eb5a6110a93317/lxml-6.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:310b719b695b3dd442cdfbbe64936b2f2e231bb91d998e99e6f0daf991a3eba3", size = 4014711, upload-time = "2025-06-26T16:26:33.723Z" },
+    { url = "https://files.pythonhosted.org/packages/55/10/dc8e5290ae4c94bdc1a4c55865be7e1f31dfd857a88b21cbba68b5fea61b/lxml-6.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:8cb26f51c82d77483cdcd2b4a53cda55bbee29b3c2f3ddeb47182a2a9064e4eb", size = 3674431, upload-time = "2025-06-26T16:26:35.959Z" },
+    { url = "https://files.pythonhosted.org/packages/79/21/6e7c060822a3c954ff085e5e1b94b4a25757c06529eac91e550f3f5cd8b8/lxml-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6da7cd4f405fd7db56e51e96bff0865b9853ae70df0e6720624049da76bde2da", size = 8414372, upload-time = "2025-06-26T16:26:39.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/051b1607a459db670fc3a244fa4f06f101a8adf86cda263d1a56b3a4f9d5/lxml-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b34339898bb556a2351a1830f88f751679f343eabf9cf05841c95b165152c9e7", size = 4593940, upload-time = "2025-06-26T16:26:41.891Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/74/dd595d92a40bda3c687d70d4487b2c7eff93fd63b568acd64fedd2ba00fe/lxml-6.0.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:51a5e4c61a4541bd1cd3ba74766d0c9b6c12d6a1a4964ef60026832aac8e79b3", size = 5214329, upload-time = "2025-06-26T16:26:44.669Z" },
+    { url = "https://files.pythonhosted.org/packages/52/46/3572761efc1bd45fcafb44a63b3b0feeb5b3f0066886821e94b0254f9253/lxml-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d18a25b19ca7307045581b18b3ec9ead2b1db5ccd8719c291f0cd0a5cec6cb81", size = 4947559, upload-time = "2025-06-28T18:47:31.091Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8a/5e40de920e67c4f2eef9151097deb9b52d86c95762d8ee238134aff2125d/lxml-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4f0c66df4386b75d2ab1e20a489f30dc7fd9a06a896d64980541506086be1f1", size = 5102143, upload-time = "2025-06-28T18:47:33.612Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4b/20555bdd75d57945bdabfbc45fdb1a36a1a0ff9eae4653e951b2b79c9209/lxml-6.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4b481b6cc3a897adb4279216695150bbe7a44c03daba3c894f49d2037e0a24", size = 5021931, upload-time = "2025-06-26T16:26:47.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/cf03b412f3763d4ca23b25e70c96a74cfece64cec3addf1c4ec639586b13/lxml-6.0.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a78d6c9168f5bcb20971bf3329c2b83078611fbe1f807baadc64afc70523b3a", size = 5645469, upload-time = "2025-07-03T19:19:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/39c8507c16db6031f8c1ddf70ed95dbb0a6d466a40002a3522c128aba472/lxml-6.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae06fbab4f1bb7db4f7c8ca9897dc8db4447d1a2b9bee78474ad403437bcc29", size = 5247467, upload-time = "2025-06-26T16:26:49.998Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/732d49def0631ad633844cfb2664563c830173a98d5efd9b172e89a4800d/lxml-6.0.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:1fa377b827ca2023244a06554c6e7dc6828a10aaf74ca41965c5d8a4925aebb4", size = 4720601, upload-time = "2025-06-26T16:26:52.564Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7f/6b956fab95fa73462bca25d1ea7fc8274ddf68fb8e60b78d56c03b65278e/lxml-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1676b56d48048a62ef77a250428d1f31f610763636e0784ba67a9740823988ca", size = 5060227, upload-time = "2025-06-26T16:26:55.054Z" },
+    { url = "https://files.pythonhosted.org/packages/97/06/e851ac2924447e8b15a294855caf3d543424364a143c001014d22c8ca94c/lxml-6.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0e32698462aacc5c1cf6bdfebc9c781821b7e74c79f13e5ffc8bfe27c42b1abf", size = 4790637, upload-time = "2025-06-26T16:26:57.384Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d4/fd216f3cd6625022c25b336c7570d11f4a43adbaf0a56106d3d496f727a7/lxml-6.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4d6036c3a296707357efb375cfc24bb64cd955b9ec731abf11ebb1e40063949f", size = 5662049, upload-time = "2025-07-03T19:19:16.409Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/0e764ce00b95e008d76b99d432f1807f3574fb2945b496a17807a1645dbd/lxml-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7488a43033c958637b1a08cddc9188eb06d3ad36582cebc7d4815980b47e27ef", size = 5272430, upload-time = "2025-06-26T16:27:00.031Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/01/d48cc141bc47bc1644d20fe97bbd5e8afb30415ec94f146f2f76d0d9d098/lxml-6.0.0-cp313-cp313-win32.whl", hash = "sha256:5fcd7d3b1d8ecb91445bd71b9c88bdbeae528fefee4f379895becfc72298d181", size = 3612896, upload-time = "2025-06-26T16:27:04.251Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/87/6456b9541d186ee7d4cb53bf1b9a0d7f3b1068532676940fdd594ac90865/lxml-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:2f34687222b78fff795feeb799a7d44eca2477c3d9d3a46ce17d51a4f383e32e", size = 4013132, upload-time = "2025-06-26T16:27:06.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/42/85b3aa8f06ca0d24962f8100f001828e1f1f1a38c954c16e71154ed7d53a/lxml-6.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:21db1ec5525780fd07251636eb5f7acb84003e9382c72c18c542a87c416ade03", size = 3672642, upload-time = "2025-06-26T16:27:09.888Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
+]
+
+[[package]]
+name = "normality"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "banal" },
+    { name = "chardet" },
+    { name = "charset-normalizer" },
+    { name = "pyicu" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/ce/8d469c4f2431346f067f840e2cc15177771bdb14095456023de84e1a7b5c/normality-3.0.1-py3-none-any.whl", hash = "sha256:c282c1990eb65b2859649a2ffca9fee081f6b106f45ff62e37db1418a0c8fae6", size = 17383, upload-time = "2025-07-27T12:02:37.997Z" },
+]
+
+[[package]]
+name = "packageurl-python"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/f0/de0ac00a4484c0d87b71e3d9985518278d89797fa725e90abd3453bccb42/packageurl_python-0.17.5.tar.gz", hash = "sha256:a7be3f3ba70d705f738ace9bf6124f31920245a49fa69d4b416da7037dd2de61", size = 43832, upload-time = "2025-08-06T14:08:20.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/78/9dbb7d2ef240d20caf6f79c0f66866737c9d0959601fd783ff635d1d019d/packageurl_python-0.17.5-py3-none-any.whl", hash = "sha256:f0e55452ab37b5c192c443de1458e3f3b4d8ac27f747df6e8c48adeab081d321", size = 30544, upload-time = "2025-08-06T14:08:19.055Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "packvers"
+version = "21.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/1b/dfb8654324222e996a18297b2b2b21b637cad0a23d75134cc1fd129dd7c0/packvers-21.5.tar.gz", hash = "sha256:2d2758fc09d2c325414354b8478d649f878b52c38598517fba51c8623526ca79", size = 84862, upload-time = "2022-12-22T10:51:26.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/0c/a57d44f7f970ea31dfcda7ffbe8509d087c2386a28b791867a8868fc66da/packvers-21.5-py3-none-any.whl", hash = "sha256:a05e4a2b0f2eecb49d2568bfe180168a99165ab5167aa791f82266e33740ac87", size = 40762, upload-time = "2022-12-22T10:51:23.381Z" },
+]
+
+[[package]]
+name = "parameter-expansion-patched"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/15/0c6fa115b269418a0d53d4564809afb74684d8afa417323b406be26de08b/parameter-expansion-patched-0.3.1.tar.gz", hash = "sha256:ff5dbc89fbde582f3336562d196b710771e92baa7b6d59356a14b085a0b6740b", size = 14584, upload-time = "2022-05-04T14:54:59.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/9f/2eb2762808faed5218faba5559415b5bb62b39376cf9a38acc01f9786481/parameter_expansion_patched-0.3.1-py3-none-any.whl", hash = "sha256:832f04bed2a81e32d9d233cbe27448a7a22edf9a744086dbd01066c41ad0f535", size = 11839, upload-time = "2022-05-04T14:54:56.296Z" },
+]
+
+[[package]]
+name = "pdfminer-six"
+version = "20250506"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/46/5223d613ac4963e1f7c07b2660fe0e9e770102ec6bda8c038400113fb215/pdfminer_six-20250506.tar.gz", hash = "sha256:b03cc8df09cf3c7aba8246deae52e0bca7ebb112a38895b5e1d4f5dd2b8ca2e7", size = 7387678, upload-time = "2025-05-06T16:17:00.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/16/7a432c0101fa87457e75cb12c879e1749c5870a786525e2e0f42871d6462/pdfminer_six-20250506-py3-none-any.whl", hash = "sha256:d81ad173f62e5f841b53a8ba63af1a4a355933cfc0ffabd608e568b9193909e3", size = 5620187, upload-time = "2025-05-06T16:16:58.669Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
+name = "pkginfo2"
+version = "30.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/8d/09cc1c99a30ac14050fc4e04e549e024be83ff72a7f63e75023501baf977/pkginfo2-30.0.0.tar.gz", hash = "sha256:5e1afbeb156febb407a9b5c16b51c5b4737c529eeda2b1607e1e277cf260669c", size = 364071, upload-time = "2022-01-27T23:56:14.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/01/4e506c68c9ea09c702b1eac87e6d2cda6d6633e6ed42ec1f43662e246769/pkginfo2-30.0.0-py3-none-any.whl", hash = "sha256:f1558f3ff71c99e8f362b6d079c15ef334dfce8ab2bc623a992341baeb1e7248", size = 25701, upload-time = "2022-01-27T23:56:11.381Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "plugincode"
+version = "32.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "commoncode" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/0d/e934e7ae95363f9504e78b5f962efd62add3659aa9ad7c79b6f34faa81e6/plugincode-32.0.0.tar.gz", hash = "sha256:4132d93b1755271c6e226c9da2e2044ff62ebcb873b5e958d66a8ddde9f345fa", size = 71325, upload-time = "2023-05-02T19:14:00.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/6f/d38bd65c3bcb3787d6cf944c8458e45cd38f8dea0ef7587ff2998e786595/plugincode-32.0.0-py3-none-any.whl", hash = "sha256:344bb9943fcf4d6d05669c3c61efd4093fffa6a290fba7c5c11db15f2b51305e", size = 19000, upload-time = "2023-05-02T19:13:58.966Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "publicsuffix2"
+version = "2.20191221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/04/1759906c4c5b67b2903f546de234a824d4028ef24eb0b1122daa43376c20/publicsuffix2-2.20191221.tar.gz", hash = "sha256:00f8cc31aa8d0d5592a5ced19cccba7de428ebca985db26ac852d920ddd6fe7b", size = 99592, upload-time = "2019-12-21T11:30:44.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/16/053c2945c5e3aebeefb4ccd5c5e7639e38bc30ad1bdc7ce86c6d01707726/publicsuffix2-2.20191221-py2.py3-none-any.whl", hash = "sha256:786b5e36205b88758bd3518725ec8cfe7a8173f5269354641f581c6b80a99893", size = 89033, upload-time = "2019-12-21T11:30:41.744Z" },
+]
+
+[[package]]
+name = "pyahocorasick"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/4b/e3bee663803e2202be984e1291084355f064dfa3a6a632e01fe496445a5c/pyahocorasick-2.2.0.tar.gz", hash = "sha256:817f302088400a1402bf2f8631fdb21cf5a2666888e0d6a7d5a3ad556212e9da", size = 103916, upload-time = "2025-06-19T05:51:28.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/a6/b88ab854348f8449a544a435abb270ed65ed5b77ceada372ef9e998f367c/pyahocorasick-2.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:744f63790fc4d337e129c80d28f57e6ba4d22a4b7e065825c72e98f92a77e16b", size = 58174, upload-time = "2025-06-19T05:51:07.874Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/6aa83f4f2852d03ce28872c139580913532a85686fc49f5136e4a7efce23/pyahocorasick-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73bb94c5621565c5ad22d2f44d45edc7e568de5bd629d22a435e76d7023dae4e", size = 33285, upload-time = "2025-06-19T05:51:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e5/088c0169c36581d961eb24d770a3c0a48b95d029fd12fa343f7c1a28c11f/pyahocorasick-2.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c3fb6406b3311319bef625f0269af276b75f834e5cba33b81f2e8c35a9c6c91", size = 114871, upload-time = "2025-06-19T05:51:10.513Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e5/d3198bba8ce7cdf4c946f71a15bf75b26e2796b805ad43041a0ea77c422d/pyahocorasick-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:346f92c0086589e44c279d1519187bd3421d94836875033b27b7730f11bc923e", size = 117872, upload-time = "2025-06-19T05:51:11.859Z" },
+    { url = "https://files.pythonhosted.org/packages/55/15/ebd27c91dcb49487f8032e6046c11bee9037c793eb045a87d4df40c0af60/pyahocorasick-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:1dbc761cdf8c9a1b85f065fb2442c234b742203df8e3cd2f38fc45e4838b02d3", size = 35028, upload-time = "2025-06-19T05:51:12.936Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/d62a60af6025bc02ef2d25f29f93c591c06f4e43e51b2127f9a4a0954eb8/pyahocorasick-2.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9604d73051f96c2d5a6c267f404f3d2d02790a2680a0c0ee7069ef7660d8b", size = 58177, upload-time = "2025-06-19T05:51:13.999Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/b3cf05d0a3e545ce38a10c828fb188500a31261b679fd15ef717147eadee/pyahocorasick-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:57932f7e894107d5ddf011051feb081b0ff7fdd6ab94462ead0c4c716ffdbd47", size = 33285, upload-time = "2025-06-19T05:51:15.687Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/44/b1cd7d1b35a5f77b45b5694def4a8e6560b44cafc0dce12b7dc19a609dbe/pyahocorasick-2.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c4489c2615fc4a25824d1f12c9e775d84c2207eecedde273bbffd479d82e71", size = 114812, upload-time = "2025-06-19T05:51:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/61/48/862fc0d3c92aa70a7c1721aa41460b8ac0a8d2e62aab039773c9b8d0c9d9/pyahocorasick-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f388b66e8973e8ac7cd7db7f90c56b2aaec4b5563b6da7bfc3e973b7ea34e1d", size = 117865, upload-time = "2025-06-19T05:51:18.619Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/7680654f2d5e06ed7df9c7e6387cf86ed48c670fc65d64924a9a03ccb0e7/pyahocorasick-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:8eabbd6fcd65595d36dadc3fc57d536aa302833991cd6b0b872aae60c5eac3e9", size = 35021, upload-time = "2025-06-19T05:51:19.79Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
+
+[[package]]
+name = "pygmars"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/e2/84b8d7329ae869f2c7ed8b9e50c035806e50b3b1977ae232fc1d78404644/pygmars-1.0.0.tar.gz", hash = "sha256:de5c6673941eb4c5965f219e64b6638d08237ed76aa7d412ee29819c90a93936", size = 86809, upload-time = "2025-07-16T23:48:27.132Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/4b/463043f8c9967cbeaa3e712c7d62e6d81a8bc66c43eb5f2e4bee28cdedb8/pygmars-1.0.0-py3-none-any.whl", hash = "sha256:69b75840f28ff5489de69b2604f100b0550a6ceee4e6aaefd60bc5d4b0025728", size = 32839, upload-time = "2025-07-16T23:48:26.184Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyicu"
+version = "2.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/57/9db810ab75133a1c87ac2e327fb59199d78d233f575fbb63bfd3492b769c/pyicu-2.15.2.tar.gz", hash = "sha256:561e77eedff17cec6839f26211f7a5ce3c071b776e8a0ec9d1207f46cbce598f", size = 267721, upload-time = "2025-04-22T18:54:45.364Z" }
+
+[[package]]
+name = "pymaven-patch"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/5a/5de519f07057838d4768ed7f04ceea0629b373e06aa96bddfa7bb8d78654/pymaven-patch-0.3.2.tar.gz", hash = "sha256:0cf7c93e89f01f0408eb656eec58cb4a228c95e03b3d47cb73d31f899055cd50", size = 31017, upload-time = "2024-03-21T08:45:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/9a/9e597fcd70da0c2e34a9b3c60df62f23a6972295caa68f6d482b57db937b/pymaven_patch-0.3.2-py3-none-any.whl", hash = "sha256:29a67d508e5d7a55c4359435e009ab87217ceb604a48caeb7b5b7d26b3099f65", size = 23953, upload-time = "2024-03-21T08:45:00.017Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/7e/cb2d74466bd8495051ebe2d241b1cb1d4acf9740d481126aef19ef2697f5/rdflib-7.1.4.tar.gz", hash = "sha256:fed46e24f26a788e2ab8e445f7077f00edcf95abb73bcef4b86cefa8b62dd174", size = 4692745, upload-time = "2025-03-29T02:23:02.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/31/e9b6f04288dcd3fa60cb3179260d6dad81b92aef3063d679ac7d80a827ea/rdflib-7.1.4-py3-none-any.whl", hash = "sha256:72f4adb1990fa5241abd22ddaf36d7cafa5d91d9ff2ba13f3086d339b213d997", size = 565051, upload-time = "2025-03-29T02:22:44.987Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[package.optional-dependencies]
+use-chardet-on-py3 = [
+    { name = "chardet" },
+]
+
+[[package]]
+name = "riot-sbom"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "scancode-toolkit" },
+    { name = "spdx-tools" },
+]
+
+[package.dev-dependencies]
+test = [
+    { name = "jsonschema" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "scancode-toolkit", specifier = ">=32.3.3,<33.0.0" },
+    { name = "spdx-tools", specifier = ">=0.8.2,<1.0.0" },
+]
+
+[package.metadata.requires-dev]
+test = [{ name = "jsonschema", specifier = ">=4.23.0,<5.0.0" }]
+
+[[package]]
+name = "rpds-py"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/aa/4456d84bbb54adc6a916fb10c9b374f78ac840337644e4a5eda229c81275/rpds_py-0.26.0.tar.gz", hash = "sha256:20dae58a859b0906f0685642e591056f1e787f3a8b39c8e8749a45dc7d26bdb0", size = 27385, upload-time = "2025-07-01T15:57:13.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/86/90eb87c6f87085868bd077c7a9938006eb1ce19ed4d06944a90d3560fce2/rpds_py-0.26.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:894514d47e012e794f1350f076c427d2347ebf82f9b958d554d12819849a369d", size = 363933, upload-time = "2025-07-01T15:54:15.734Z" },
+    { url = "https://files.pythonhosted.org/packages/63/78/4469f24d34636242c924626082b9586f064ada0b5dbb1e9d096ee7a8e0c6/rpds_py-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc921b96fa95a097add244da36a1d9e4f3039160d1d30f1b35837bf108c21136", size = 350447, upload-time = "2025-07-01T15:54:16.922Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/91/c448ed45efdfdade82348d5e7995e15612754826ea640afc20915119734f/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1157659470aa42a75448b6e943c895be8c70531c43cb78b9ba990778955582", size = 384711, upload-time = "2025-07-01T15:54:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/43/e5c86fef4be7f49828bdd4ecc8931f0287b1152c0bb0163049b3218740e7/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:521ccf56f45bb3a791182dc6b88ae5f8fa079dd705ee42138c76deb1238e554e", size = 400865, upload-time = "2025-07-01T15:54:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/55/34/e00f726a4d44f22d5c5fe2e5ddd3ac3d7fd3f74a175607781fbdd06fe375/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9def736773fd56b305c0eef698be5192c77bfa30d55a0e5885f80126c4831a15", size = 517763, upload-time = "2025-07-01T15:54:20.858Z" },
+    { url = "https://files.pythonhosted.org/packages/52/1c/52dc20c31b147af724b16104500fba13e60123ea0334beba7b40e33354b4/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdad4ea3b4513b475e027be79e5a0ceac8ee1c113a1a11e5edc3c30c29f964d8", size = 406651, upload-time = "2025-07-01T15:54:22.508Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/77/87d7bfabfc4e821caa35481a2ff6ae0b73e6a391bb6b343db2c91c2b9844/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82b165b07f416bdccf5c84546a484cc8f15137ca38325403864bfdf2b5b72f6a", size = 386079, upload-time = "2025-07-01T15:54:23.987Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d4/7f2200c2d3ee145b65b3cddc4310d51f7da6a26634f3ac87125fd789152a/rpds_py-0.26.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d04cab0a54b9dba4d278fe955a1390da3cf71f57feb78ddc7cb67cbe0bd30323", size = 421379, upload-time = "2025-07-01T15:54:25.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/13/9fdd428b9c820869924ab62236b8688b122baa22d23efdd1c566938a39ba/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:79061ba1a11b6a12743a2b0f72a46aa2758613d454aa6ba4f5a265cc48850158", size = 562033, upload-time = "2025-07-01T15:54:26.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e1/b69686c3bcbe775abac3a4c1c30a164a2076d28df7926041f6c0eb5e8d28/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f405c93675d8d4c5ac87364bb38d06c988e11028a64b52a47158a355079661f3", size = 591639, upload-time = "2025-07-01T15:54:27.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/1e3d8c8863c84a90197ac577bbc3d796a92502124c27092413426f670990/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dafd4c44b74aa4bed4b250f1aed165b8ef5de743bcca3b88fc9619b6087093d2", size = 557105, upload-time = "2025-07-01T15:54:29.93Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c5/90c569649057622959f6dcc40f7b516539608a414dfd54b8d77e3b201ac0/rpds_py-0.26.0-cp312-cp312-win32.whl", hash = "sha256:3da5852aad63fa0c6f836f3359647870e21ea96cf433eb393ffa45263a170d44", size = 223272, upload-time = "2025-07-01T15:54:31.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/16/19f5d9f2a556cfed454eebe4d354c38d51c20f3db69e7b4ce6cff904905d/rpds_py-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf47cfdabc2194a669dcf7a8dbba62e37a04c5041d2125fae0233b720da6f05c", size = 234995, upload-time = "2025-07-01T15:54:32.195Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f0/7935e40b529c0e752dfaa7880224771b51175fce08b41ab4a92eb2fbdc7f/rpds_py-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:20ab1ae4fa534f73647aad289003f1104092890849e0266271351922ed5574f8", size = 223198, upload-time = "2025-07-01T15:54:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/67/bb62d0109493b12b1c6ab00de7a5566aa84c0e44217c2d94bee1bd370da9/rpds_py-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:696764a5be111b036256c0b18cd29783fab22154690fc698062fc1b0084b511d", size = 363917, upload-time = "2025-07-01T15:54:34.755Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/34e6ae1925a5706c0f002a8d2d7f172373b855768149796af87bd65dcdb9/rpds_py-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6c15d2080a63aaed876e228efe4f814bc7889c63b1e112ad46fdc8b368b9e1", size = 350073, upload-time = "2025-07-01T15:54:36.292Z" },
+    { url = "https://files.pythonhosted.org/packages/75/83/1953a9d4f4e4de7fd0533733e041c28135f3c21485faaef56a8aadbd96b5/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:390e3170babf42462739a93321e657444f0862c6d722a291accc46f9d21ed04e", size = 384214, upload-time = "2025-07-01T15:54:37.469Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0e/983ed1b792b3322ea1d065e67f4b230f3b96025f5ce3878cc40af09b7533/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7da84c2c74c0f5bc97d853d9e17bb83e2dcafcff0dc48286916001cc114379a1", size = 400113, upload-time = "2025-07-01T15:54:38.954Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/36c0925fff6f660a80be259c5b4f5e53a16851f946eb080351d057698528/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c5fe114a6dd480a510b6d3661d09d67d1622c4bf20660a474507aaee7eeeee9", size = 515189, upload-time = "2025-07-01T15:54:40.57Z" },
+    { url = "https://files.pythonhosted.org/packages/13/45/cbf07fc03ba7a9b54662c9badb58294ecfb24f828b9732970bd1a431ed5c/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3100b3090269f3a7ea727b06a6080d4eb7439dca4c0e91a07c5d133bb1727ea7", size = 406998, upload-time = "2025-07-01T15:54:43.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b0/8fa5e36e58657997873fd6a1cf621285ca822ca75b4b3434ead047daa307/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c03c9b0c64afd0320ae57de4c982801271c0c211aa2d37f3003ff5feb75bb04", size = 385903, upload-time = "2025-07-01T15:54:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/b25437772f9f57d7a9fbd73ed86d0dcd76b4c7c6998348c070d90f23e315/rpds_py-0.26.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5963b72ccd199ade6ee493723d18a3f21ba7d5b957017607f815788cef50eaf1", size = 419785, upload-time = "2025-07-01T15:54:46.043Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/63ffa55743dfcb4baf2e9e77a0b11f7f97ed96a54558fcb5717a4b2cd732/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9da4e873860ad5bab3291438525cae80169daecbfafe5657f7f5fb4d6b3f96b9", size = 561329, upload-time = "2025-07-01T15:54:47.64Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/1f4f5e2886c480a2346b1e6759c00278b8a69e697ae952d82ae2e6ee5db0/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5afaddaa8e8c7f1f7b4c5c725c0070b6eed0228f705b90a1732a48e84350f4e9", size = 590875, upload-time = "2025-07-01T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/e6639f1b91c3a55f8c41b47d73e6307051b6e246254a827ede730624c0f8/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4916dc96489616a6f9667e7526af8fa693c0fdb4f3acb0e5d9f4400eb06a47ba", size = 556636, upload-time = "2025-07-01T15:54:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4c/b3917c45566f9f9a209d38d9b54a1833f2bb1032a3e04c66f75726f28876/rpds_py-0.26.0-cp313-cp313-win32.whl", hash = "sha256:2a343f91b17097c546b93f7999976fd6c9d5900617aa848c81d794e062ab302b", size = 222663, upload-time = "2025-07-01T15:54:52.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0b/0851bdd6025775aaa2365bb8de0697ee2558184c800bfef8d7aef5ccde58/rpds_py-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:0a0b60701f2300c81b2ac88a5fb893ccfa408e1c4a555a77f908a2596eb875a5", size = 234428, upload-time = "2025-07-01T15:54:53.692Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e8/a47c64ed53149c75fb581e14a237b7b7cd18217e969c30d474d335105622/rpds_py-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:257d011919f133a4746958257f2c75238e3ff54255acd5e3e11f3ff41fd14256", size = 222571, upload-time = "2025-07-01T15:54:54.822Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bf/3d970ba2e2bcd17d2912cb42874107390f72873e38e79267224110de5e61/rpds_py-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:529c8156d7506fba5740e05da8795688f87119cce330c244519cf706a4a3d618", size = 360475, upload-time = "2025-07-01T15:54:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9f/283e7e2979fc4ec2d8ecee506d5a3675fce5ed9b4b7cb387ea5d37c2f18d/rpds_py-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f53ec51f9d24e9638a40cabb95078ade8c99251945dad8d57bf4aabe86ecee35", size = 346692, upload-time = "2025-07-01T15:54:58.561Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/03/7e50423c04d78daf391da3cc4330bdb97042fc192a58b186f2d5deb7befd/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab504c4d654e4a29558eaa5bb8cea5fdc1703ea60a8099ffd9c758472cf913f", size = 379415, upload-time = "2025-07-01T15:54:59.751Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/d11ee60d4d3b16808432417951c63df803afb0e0fc672b5e8d07e9edaaae/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd0641abca296bc1a00183fe44f7fced8807ed49d501f188faa642d0e4975b83", size = 391783, upload-time = "2025-07-01T15:55:00.898Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/1069c394d9c0d6d23c5b522e1f6546b65793a22950f6e0210adcc6f97c3e/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b312fecc1d017b5327afa81d4da1480f51c68810963a7336d92203dbb3d4f1", size = 512844, upload-time = "2025-07-01T15:55:02.201Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3b/c4fbf0926800ed70b2c245ceca99c49f066456755f5d6eb8863c2c51e6d0/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c741107203954f6fc34d3066d213d0a0c40f7bb5aafd698fb39888af277c70d8", size = 402105, upload-time = "2025-07-01T15:55:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/db69b52ca07413e568dae9dc674627a22297abb144c4d6022c6d78f1e5cc/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc3e55a7db08dc9a6ed5fb7103019d2c1a38a349ac41901f9f66d7f95750942f", size = 383440, upload-time = "2025-07-01T15:55:05.398Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e1/c65255ad5b63903e56b3bb3ff9dcc3f4f5c3badde5d08c741ee03903e951/rpds_py-0.26.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e851920caab2dbcae311fd28f4313c6953993893eb5c1bb367ec69d9a39e7ed", size = 412759, upload-time = "2025-07-01T15:55:08.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/22/bb731077872377a93c6e93b8a9487d0406c70208985831034ccdeed39c8e/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dfbf280da5f876d0b00c81f26bedce274e72a678c28845453885a9b3c22ae632", size = 556032, upload-time = "2025-07-01T15:55:09.52Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/8b/393322ce7bac5c4530fb96fc79cc9ea2f83e968ff5f6e873f905c493e1c4/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1cc81d14ddfa53d7f3906694d35d54d9d3f850ef8e4e99ee68bc0d1e5fed9a9c", size = 585416, upload-time = "2025-07-01T15:55:11.216Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ae/769dc372211835bf759319a7aae70525c6eb523e3371842c65b7ef41c9c6/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dca83c498b4650a91efcf7b88d669b170256bf8017a5db6f3e06c2bf031f57e0", size = 554049, upload-time = "2025-07-01T15:55:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/4c43f9cc203d6ba44ce3146246cdc38619d92c7bd7bad4946a3491bd5b70/rpds_py-0.26.0-cp313-cp313t-win32.whl", hash = "sha256:4d11382bcaf12f80b51d790dee295c56a159633a8e81e6323b16e55d81ae37e9", size = 218428, upload-time = "2025-07-01T15:55:14.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8b/9286b7e822036a4a977f2f1e851c7345c20528dbd56b687bb67ed68a8ede/rpds_py-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff110acded3c22c033e637dd8896e411c7d3a11289b2edf041f86663dbc791e9", size = 231524, upload-time = "2025-07-01T15:55:15.745Z" },
+    { url = "https://files.pythonhosted.org/packages/55/07/029b7c45db910c74e182de626dfdae0ad489a949d84a468465cd0ca36355/rpds_py-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:da619979df60a940cd434084355c514c25cf8eb4cf9a508510682f6c851a4f7a", size = 364292, upload-time = "2025-07-01T15:55:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d1/9b3d3f986216b4d1f584878dca15ce4797aaf5d372d738974ba737bf68d6/rpds_py-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea89a2458a1a75f87caabefe789c87539ea4e43b40f18cff526052e35bbb4fdf", size = 350334, upload-time = "2025-07-01T15:55:18.922Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/16d5e7bc9ec715fa9668731d0cf97f6b032724e61696e2db3d47aeb89214/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feac1045b3327a45944e7dcbeb57530339f6b17baff154df51ef8b0da34c8c12", size = 384875, upload-time = "2025-07-01T15:55:20.399Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/13/aa5e2b1ec5ab0e86a5c464d53514c0467bec6ba2507027d35fc81818358e/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b818a592bd69bfe437ee8368603d4a2d928c34cffcdf77c2e761a759ffd17d20", size = 399993, upload-time = "2025-07-01T15:55:21.729Z" },
+    { url = "https://files.pythonhosted.org/packages/17/03/8021810b0e97923abdbab6474c8b77c69bcb4b2c58330777df9ff69dc559/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a8b0dd8648709b62d9372fc00a57466f5fdeefed666afe3fea5a6c9539a0331", size = 516683, upload-time = "2025-07-01T15:55:22.918Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b1/da8e61c87c2f3d836954239fdbbfb477bb7b54d74974d8f6fcb34342d166/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d3498ad0df07d81112aa6ec6c95a7e7b1ae00929fb73e7ebee0f3faaeabad2f", size = 408825, upload-time = "2025-07-01T15:55:24.207Z" },
+    { url = "https://files.pythonhosted.org/packages/38/bc/1fc173edaaa0e52c94b02a655db20697cb5fa954ad5a8e15a2c784c5cbdd/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4146ccb15be237fdef10f331c568e1b0e505f8c8c9ed5d67759dac58ac246", size = 387292, upload-time = "2025-07-01T15:55:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/eb/3a9bb4bd90867d21916f253caf4f0d0be7098671b6715ad1cead9fe7bab9/rpds_py-0.26.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9a63785467b2d73635957d32a4f6e73d5e4df497a16a6392fa066b753e87387", size = 420435, upload-time = "2025-07-01T15:55:27.798Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/16/e066dcdb56f5632713445271a3f8d3d0b426d51ae9c0cca387799df58b02/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de4ed93a8c91debfd5a047be327b7cc8b0cc6afe32a716bbbc4aedca9e2a83af", size = 562410, upload-time = "2025-07-01T15:55:29.057Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/ddbdec7eb82a0dc2e455be44c97c71c232983e21349836ce9f272e8a3c29/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:caf51943715b12af827696ec395bfa68f090a4c1a1d2509eb4e2cb69abbbdb33", size = 590724, upload-time = "2025-07-01T15:55:30.719Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/95744085e65b7187d83f2fcb0bef70716a1ea0a9e5d8f7f39a86e5d83424/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4a59e5bc386de021f56337f757301b337d7ab58baa40174fb150accd480bc953", size = 558285, upload-time = "2025-07-01T15:55:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/37/37/6309a75e464d1da2559446f9c811aa4d16343cebe3dbb73701e63f760caa/rpds_py-0.26.0-cp314-cp314-win32.whl", hash = "sha256:92c8db839367ef16a662478f0a2fe13e15f2227da3c1430a782ad0f6ee009ec9", size = 223459, upload-time = "2025-07-01T15:55:33.312Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/8e9c11214c46098b1d1391b7e02b70bb689ab963db3b19540cba17315291/rpds_py-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0afb8cdd034150d4d9f53926226ed27ad15b7f465e93d7468caaf5eafae0d37", size = 236083, upload-time = "2025-07-01T15:55:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/47/af/9c4638994dd623d51c39892edd9d08e8be8220a4b7e874fa02c2d6e91955/rpds_py-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:ca3f059f4ba485d90c8dc75cb5ca897e15325e4e609812ce57f896607c1c0867", size = 223291, upload-time = "2025-07-01T15:55:36.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/db/669a241144460474aab03e254326b32c42def83eb23458a10d163cb9b5ce/rpds_py-0.26.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5afea17ab3a126006dc2f293b14ffc7ef3c85336cf451564a0515ed7648033da", size = 361445, upload-time = "2025-07-01T15:55:37.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/133f61cc5807c6c2fd086a46df0eb8f63a23f5df8306ff9f6d0fd168fecc/rpds_py-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:69f0c0a3df7fd3a7eec50a00396104bb9a843ea6d45fcc31c2d5243446ffd7a7", size = 347206, upload-time = "2025-07-01T15:55:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bf/0e8fb4c05f70273469eecf82f6ccf37248558526a45321644826555db31b/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:801a71f70f9813e82d2513c9a96532551fce1e278ec0c64610992c49c04c2dad", size = 380330, upload-time = "2025-07-01T15:55:40.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a8/060d24185d8b24d3923322f8d0ede16df4ade226a74e747b8c7c978e3dd3/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df52098cde6d5e02fa75c1f6244f07971773adb4a26625edd5c18fee906fa84d", size = 392254, upload-time = "2025-07-01T15:55:42.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/7b/7c2e8a9ee3e6bc0bae26bf29f5219955ca2fbb761dca996a83f5d2f773fe/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bc596b30f86dc6f0929499c9e574601679d0341a0108c25b9b358a042f51bca", size = 516094, upload-time = "2025-07-01T15:55:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/f61cafbed8ba1499b9af9f1777a2a199cd888f74a96133d8833ce5eaa9c5/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dfbe56b299cf5875b68eb6f0ebaadc9cac520a1989cac0db0765abfb3709c19", size = 402889, upload-time = "2025-07-01T15:55:45.275Z" },
+    { url = "https://files.pythonhosted.org/packages/92/19/c8ac0a8a8df2dd30cdec27f69298a5c13e9029500d6d76718130f5e5be10/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac64f4b2bdb4ea622175c9ab7cf09444e412e22c0e02e906978b3b488af5fde8", size = 384301, upload-time = "2025-07-01T15:55:47.098Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/6b1859898bc292a9ce5776016c7312b672da00e25cec74d7beced1027286/rpds_py-0.26.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:181ef9b6bbf9845a264f9aa45c31836e9f3c1f13be565d0d010e964c661d1e2b", size = 412891, upload-time = "2025-07-01T15:55:48.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b9/ceb39af29913c07966a61367b3c08b4f71fad841e32c6b59a129d5974698/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49028aa684c144ea502a8e847d23aed5e4c2ef7cadfa7d5eaafcb40864844b7a", size = 557044, upload-time = "2025-07-01T15:55:49.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/27/35637b98380731a521f8ec4f3fd94e477964f04f6b2f8f7af8a2d889a4af/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e5d524d68a474a9688336045bbf76cb0def88549c1b2ad9dbfec1fb7cfbe9170", size = 585774, upload-time = "2025-07-01T15:55:51.192Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d9/3f0f105420fecd18551b678c9a6ce60bd23986098b252a56d35781b3e7e9/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1851f429b822831bd2edcbe0cfd12ee9ea77868f8d3daf267b189371671c80e", size = 554886, upload-time = "2025-07-01T15:55:52.541Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c5/347c056a90dc8dd9bc240a08c527315008e1b5042e7a4cf4ac027be9d38a/rpds_py-0.26.0-cp314-cp314t-win32.whl", hash = "sha256:7bdb17009696214c3b66bb3590c6d62e14ac5935e53e929bcdbc5a495987a84f", size = 219027, upload-time = "2025-07-01T15:55:53.874Z" },
+    { url = "https://files.pythonhosted.org/packages/75/04/5302cea1aa26d886d34cadbf2dc77d90d7737e576c0065f357b96dc7a1a6/rpds_py-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f14440b9573a6f76b4ee4770c13f0b5921f71dde3b6fcb8dabbefd13b7fe05d7", size = 232821, upload-time = "2025-07-01T15:55:55.167Z" },
+]
+
+[[package]]
+name = "saneyaml"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/bb/b3ab128fe13964fc8da25ecbac82f9ed9beb59b2e04bfbef433886f1acb0/saneyaml-0.6.1.tar.gz", hash = "sha256:19cfbd8bf94d730998162c790fe5cec9abb5300cc5890fe37dc6dbcaa8fb16bb", size = 82235, upload-time = "2024-08-14T06:25:39.665Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/c0/b41733920cef3d87ee7d1fd5a618c7bb5240ba80dd2f29c73ec3416b3e04/saneyaml-0.6.1-py3-none-any.whl", hash = "sha256:60553363ac55433cef2bc1d6c5a1c9f6e2787e5f40e8c6fad5983eb701592c5b", size = 13063, upload-time = "2024-08-14T06:25:38.505Z" },
+]
+
+[[package]]
+name = "scancode-toolkit"
+version = "32.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "beautifulsoup4", extra = ["chardet"] },
+    { name = "boolean-py" },
+    { name = "chardet" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "commoncode" },
+    { name = "container-inspector" },
+    { name = "debian-inspector" },
+    { name = "dparse2" },
+    { name = "extractcode", extra = ["full"] },
+    { name = "fasteners" },
+    { name = "fingerprints" },
+    { name = "ftfy" },
+    { name = "gemfileparser2" },
+    { name = "html5lib" },
+    { name = "importlib-metadata" },
+    { name = "intbitset" },
+    { name = "jaraco-functools" },
+    { name = "javaproperties" },
+    { name = "jinja2" },
+    { name = "jsonstreams" },
+    { name = "license-expression" },
+    { name = "lxml" },
+    { name = "markupsafe" },
+    { name = "packageurl-python" },
+    { name = "packvers" },
+    { name = "parameter-expansion-patched" },
+    { name = "pdfminer-six" },
+    { name = "pefile" },
+    { name = "pip-requirements-parser" },
+    { name = "pkginfo2" },
+    { name = "pluggy" },
+    { name = "plugincode" },
+    { name = "publicsuffix2" },
+    { name = "pyahocorasick" },
+    { name = "pygmars" },
+    { name = "pygments" },
+    { name = "pymaven-patch" },
+    { name = "requests" },
+    { name = "saneyaml" },
+    { name = "spdx-tools" },
+    { name = "text-unidecode" },
+    { name = "toml" },
+    { name = "typecode", extra = ["full"] },
+    { name = "urlpy" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/64/2fb517058d74898864b4194397371bf351d8fad18ed6cf2e831eadbead23/scancode-toolkit-32.4.1.tar.gz", hash = "sha256:a995082de075946bf457d52af35fda388f69253b5ac9f647fcee64c0d9e97f6f", size = 21041727, upload-time = "2025-07-23T11:05:22.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/40/7fa155b1e572414e64b9f894e1e07afd4a8cf02ede2ec7c184c9e55c14f8/scancode_toolkit-32.4.1-cp312-none-any.whl", hash = "sha256:7f6b9d05753594e2957d85eaf543556a7739af4df79bd51b71c39693a5fdb614", size = 122720245, upload-time = "2025-07-23T11:05:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/12/c080769b00e408abf9029442f0df93d53ede182492a89dd5499f4e7f6219/scancode_toolkit-32.4.1-cp313-none-any.whl", hash = "sha256:258f44ce8841d1a8dbe3f5e4d63412eedfc720636d9e29100b4439ff3638fca0", size = 122720223, upload-time = "2025-07-23T11:05:13.032Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "spdx-tools"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "click" },
+    { name = "license-expression" },
+    { name = "ply" },
+    { name = "pyyaml" },
+    { name = "rdflib" },
+    { name = "semantic-version" },
+    { name = "uritools" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/d8/a67445be5981469fdbaf7f765f53c920f699e7e512cc931b650a935c3199/spdx-tools-0.8.2.tar.gz", hash = "sha256:aea4ac9c2c375e7f439b1cef5ff32ef34914c083de0f61e08ed67cd3d9deb2a9", size = 680032, upload-time = "2023-10-12T12:28:43.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/a3/5d311af9214f65b0e7106f13d14b677563533f81b4953578023051f4f916/spdx_tools-0.8.2-py3-none-any.whl", hash = "sha256:8c336c873f9caaf110693a1d38c007031e67bea53aa4b881007b680be66de934", size = 285129, upload-time = "2023-10-12T12:28:41.074Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "typecode"
+version = "30.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "binaryornot" },
+    { name = "commoncode" },
+    { name = "pdfminer-six" },
+    { name = "plugincode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ca/c93584110e501e579e8901c9ad0c5db60dc69e84dfaf2224d5f95fca067b/typecode-30.0.2.tar.gz", hash = "sha256:17689d20af0ae6116e797ef2c5de65f0ce809128cf0e68479b34bd6ba4bc3898", size = 3863273, upload-time = "2024-08-07T02:23:34.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/3c/6d135ccbbf42230d3bef43bc052fd6993171a71ce1ec868c2581d8f930ab/typecode-30.0.2-py3-none-any.whl", hash = "sha256:06b1bffa93525acf4b6a52393fd0ee20916f62ddd40c0f2d27ca75a08231a46c", size = 1027426, upload-time = "2024-08-07T02:23:31.849Z" },
+]
+
+[package.optional-dependencies]
+full = [
+    { name = "typecode-libmagic" },
+]
+
+[[package]]
+name = "typecode-libmagic"
+version = "5.39.210531"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a5/205bfb13f0a7b12135dd2991a6388862516d8974c62661c05b708a69542f/typecode_libmagic-5.39.210531-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:0a6e9745e1cdceda97cdee9d5396e65ab2025a16aa79a926350715c0ba4dfb72", size = 448663, upload-time = "2021-05-31T11:16:12.762Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/135d2c5a345f1c52431dbc92c181003ba61bcd35e304d36387e33070a9c5/typecode_libmagic-5.39.210531-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee001c8093dfa89a9d1fe6d9139ef9f367a1cb9af6fd02ffebf9246af994fbf7", size = 539467, upload-time = "2021-05-31T11:16:14.458Z" },
+    { url = "https://files.pythonhosted.org/packages/af/64/d74d4a2a84bf656ef3a7e2b9a0e00c0f36c1d56dea1a2ac06cf1add1aacb/typecode_libmagic-5.39.210531-py3-none-win_amd64.whl", hash = "sha256:24ceecb5c1249ddbdb6a471a0d35fbc11008cbd3b71cad0966f94ff94918a1fa", size = 4369549, upload-time = "2021-05-31T11:16:19.335Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+]
+
+[[package]]
+name = "uritools"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/b1/e482d43db3209663b82a59e37cf31f641254180190667c6b0bf18a297de8/uritools-5.0.0.tar.gz", hash = "sha256:68180cad154062bd5b5d9ffcdd464f8de6934414b25462ae807b00b8df9345de", size = 22730, upload-time = "2025-05-02T13:38:20.67Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/74/0987d204b5fbf83861affa6b36a20da22cb3fe708583b955c99ab834bd5a/uritools-5.0.0-py3-none-any.whl", hash = "sha256:cead3a49ba8fbca3f91857343849d506d8639718f4a2e51b62e87393b493bd6f", size = 10432, upload-time = "2025-05-02T13:38:18.703Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "urlpy"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "publicsuffix2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/21/d176a137e4cc1ec4809534d116e9a06fc5fc0519077530ab5d040e356454/urlpy-0.5.tar.gz", hash = "sha256:e98ead47f4e422ca35080fd60a039f4546b7788bbba1b0a542a34c193dfba4bc", size = 7854, upload-time = "2020-04-28T13:35:19.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/f0/43a8013e888f435c619f82b485ef8cf9fddfcceea7806d824b28d5ef8f76/urlpy-0.5-py2.py3-none-any.whl", hash = "sha256:841673d97e0dd7a4d7ba47abd49fa8e3a61709e189e40de1b04b150ce7c5ed9f", size = 9086, upload-time = "2020-04-28T13:35:16.681Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/05/51dcca9a9bf5e1bce52582683ce50980bcadbc4fa5143b9f2b19ab99958f/xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553", size = 51942, upload-time = "2024-10-16T06:10:29.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac", size = 9981, upload-time = "2024-10-16T06:10:27.649Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]


### PR DESCRIPTION
# Contribution Description

- written in python
- uses uv as build system
- obtains build information from make and build trace
- adds a few scanners for aggregating data from files and the operating system
- adds an spdx output generator
- partial test coverage

# Testing

1. use `uv` to create a virtual environment and synchronize it with the project
2. activate the virtual environment through `source .venv/bin/activate`
3. export the environment variable `RIOTBASE`, pointing to a RIOT version which satisfies below dependencies
4. execute `./run-tests.sh` in the root directory of this repository

# Dependencies

- [x] [RIOT PR 21645](https://github.com/RIOT-OS/RIOT/pull/21645) is required to make the build scanner work

# Related PRs

This is the breakout-PR for https://github.com/RIOT-OS/RIOT/pull/21530